### PR TITLE
Fix exception in CFO's `_create_condition` if all candidate start points didn't return yet

### DIFF
--- a/flaml/searcher/blendsearch.py
+++ b/flaml/searcher/blendsearch.py
@@ -1021,10 +1021,14 @@ class CFO(BlendSearchTuner):
         if self._candidate_start_points and self._thread_count == 1:
             # result needs to match or exceed the best candidate start point
             obj_best = min(
-                (self._ls.metric_op * r[self._ls.metric]
-                for r in self._candidate_start_points.values()
-                if r), default=-np.inf
+                (
+                    self._ls.metric_op * r[self._ls.metric]
+                    for r in self._candidate_start_points.values()
+                    if r
+                ),
+                default=-np.inf,
             )
+
             return result[self._ls.metric] * self._ls.metric_op <= obj_best
         else:
             return True

--- a/flaml/searcher/blendsearch.py
+++ b/flaml/searcher/blendsearch.py
@@ -1020,14 +1020,11 @@ class CFO(BlendSearchTuner):
             return False
         if self._candidate_start_points and self._thread_count == 1:
             # result needs to match or exceed the best candidate start point
-            try:
-                obj_best = min(
-                    self._ls.metric_op * r[self._ls.metric]
-                    for r in self._candidate_start_points.values()
-                    if r
-                )
-            except ValueError:
-                obj_best = np.inf
+            obj_best = min(
+                (self._ls.metric_op * r[self._ls.metric]
+                for r in self._candidate_start_points.values()
+                if r), default=-np.inf
+            )
             return result[self._ls.metric] * self._ls.metric_op <= obj_best
         else:
             return True

--- a/flaml/searcher/blendsearch.py
+++ b/flaml/searcher/blendsearch.py
@@ -1020,11 +1020,14 @@ class CFO(BlendSearchTuner):
             return False
         if self._candidate_start_points and self._thread_count == 1:
             # result needs to match or exceed the best candidate start point
-            obj_best = min(
-                self._ls.metric_op * r[self._ls.metric]
-                for r in self._candidate_start_points.values()
-                if r
-            )
+            try:
+                obj_best = min(
+                    self._ls.metric_op * r[self._ls.metric]
+                    for r in self._candidate_start_points.values()
+                    if r
+                )
+            except ValueError:
+                obj_best = np.inf
             return result[self._ls.metric] * self._ls.metric_op <= obj_best
         else:
             return True

--- a/test/tune/test_searcher_invalid_values.py
+++ b/test/tune/test_searcher_invalid_values.py
@@ -1,0 +1,62 @@
+import numpy as np
+from flaml import tune
+from flaml import BlendSearch, CFO
+
+
+def _invalid_objective(config):
+    # DragonFly uses `point`
+    metric = "point" if "point" in config else "report"
+
+    if config[metric] > 4:
+        tune.report(float("inf"))
+    elif config[metric] > 3:
+        tune.report(float("-inf"))
+    elif config[metric] > 2:
+        tune.report(np.nan)
+    else:
+        tune.report(float(config[metric]) or 0.1)
+
+
+config = {"report": tune.uniform(0.0, 5.0)}
+
+
+def test_blendsearch():
+    out = tune.run(
+        _invalid_objective,
+        search_alg=BlendSearch(
+            points_to_evaluate=[
+                {"report": 1.0},
+                {"report": 2.1},
+                {"report": 3.1},
+                {"report": 4.1},
+            ]
+        ),
+        config=config,
+        metric="_metric",
+        mode="max",
+        num_samples=16,
+    )
+
+    best_trial = out.best_trial
+    assert best_trial.config["report"] <= 2.0
+
+
+def test_cfo():
+    out = tune.run(
+        _invalid_objective,
+        search_alg=CFO(
+            points_to_evaluate=[
+                {"report": 1.0},
+                {"report": 2.1},
+                {"report": 3.1},
+                {"report": 4.1},
+            ]
+        ),
+        config=config,
+        metric="_metric",
+        mode="max",
+        num_samples=16,
+    )
+
+    best_trial = out.best_trial
+    assert best_trial.config["report"] <= 2.0


### PR DESCRIPTION
If `_create_condition` is called before the first trial returns, a `ValueError` will be raised as the `min()` in `_create_condition` will be an empty sequence. This PR fixes that.

To reproduce: run https://github.com/ray-project/ray/blob/882f7d3863059dfb361f44652815179d1dc5d1ec/python/ray/tune/tests/test_searchers.py#L125