### PR TITLE
Simplify lgbm example

### DIFF
--- a/test/ray/distribute_tune.py
+++ b/test/ray/distribute_tune.py
@@ -13,9 +13,8 @@ train_x, test_x, train_y, test_y = train_test_split(data, target, test_size=0.25
 
 def train_breast_cancer(config):
     params = LGBMEstimator(**config).params
-    num_boost_round = params.pop("n_estimators")
     train_set = lgb.Dataset(train_x, label=train_y)
-    gbm = lgb.train(params, train_set, num_boost_round)
+    gbm = lgb.train(params, train_set)
     preds = gbm.predict(test_x)
     pred_labels = np.rint(preds)
     tune.report(

--- a/test/tune.py
+++ b/test/tune.py
@@ -14,10 +14,9 @@ X_train, X_test, y_train, y_test = train_test_split(
 def train_lgbm(config: dict) -> dict:
     # convert config dict to lgbm params
     params = LGBMEstimator(**config).params
-    num_boost_round = params.pop("n_estimators")
     # train the model
     train_set = lightgbm.Dataset(X_train, y_train)
-    model = lightgbm.train(params, train_set, num_boost_round)
+    model = lightgbm.train(params, train_set)
     # evaluate the model
     pred = model.predict(X_test)
     mse = mean_squared_error(y_test, pred)

--- a/website/docs/Getting-Started.md
+++ b/website/docs/Getting-Started.md
@@ -74,7 +74,7 @@ analysis = tune.run(
     low_cost_partial_config=low_cost_partial_config, time_budget_s=3, num_samples=-1,
 )
 ```
-Please see [script](https://github.com/microsoft/FLAML/blob/main/test/tune.py) for the complete version of the above example.
+Please see this [script](https://github.com/microsoft/FLAML/blob/main/test/tune.py) for the complete version of the above example.
 
 ### Where to Go Next?
 

--- a/website/docs/Getting-Started.md
+++ b/website/docs/Getting-Started.md
@@ -49,10 +49,9 @@ from flaml.model import LGBMEstimator
 def train_lgbm(config: dict) -> dict:
     # convert config dict to lgbm params
     params = LGBMEstimator(**config).params
-    num_boost_round = params.pop("n_estimators")
     # train the model
     train_set = lightgbm.Dataset(X_train, y_train)
-    model = lightgbm.train(params, train_set, num_boost_round)
+    model = lightgbm.train(params, train_set)
     # evaluate the model
     pred = model.predict(X_test)
     mse = mean_squared_error(y_test, pred)

--- a/website/docs/Getting-Started.md
+++ b/website/docs/Getting-Started.md
@@ -74,6 +74,7 @@ analysis = tune.run(
     low_cost_partial_config=low_cost_partial_config, time_budget_s=3, num_samples=-1,
 )
 ```
+Please see [script](https://github.com/microsoft/FLAML/blob/main/test/tune.py) for the complete version of the above example.
 
 ### Where to Go Next?
 


### PR DESCRIPTION
lightgbm.train is able to take num_boost_round information from config. There is no need to seperate num_boost_round from other configuration parameters. 