### PR TITLE
corrected typo in example xgboost documentation

### DIFF
--- a/website/docs/Examples/AutoML-for-XGBoost.md
+++ b/website/docs/Examples/AutoML-for-XGBoost.md
@@ -13,7 +13,7 @@ automl = AutoML()
 settings = {
     "time_budget": 60,  # total running time in seconds
     "metric": 'r2',  # primary metrics for regression can be chosen from: ['mae','mse','r2']
-    "estimator_list": ['xgboost'],  # list of ML learners; we tune XGBoost this example
+    "estimator_list": ['xgboost'],  # list of ML learners; we tune XGBoost in this example
     "task": 'regression',  # task type  
     "log_file_name": 'houses_experiment.log',  # flaml log file
     "seed": 7654321,    # random seed

--- a/website/docs/Examples/AutoML-for-XGBoost.md
+++ b/website/docs/Examples/AutoML-for-XGBoost.md
@@ -13,7 +13,7 @@ automl = AutoML()
 settings = {
     "time_budget": 60,  # total running time in seconds
     "metric": 'r2',  # primary metrics for regression can be chosen from: ['mae','mse','r2']
-    "estimator_list": ['xgboost'],  # list of ML learners; we tune lightgbm in this example
+    "estimator_list": ['xgboost'],  # list of ML learners; we tune XGBoost this example
     "task": 'regression',  # task type  
     "log_file_name": 'houses_experiment.log',  # flaml log file
     "seed": 7654321,    # random seed


### PR DESCRIPTION
Just a presumably copy-paste error I noticed while reading the examples.