### PR TITLE
adding evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ automl.pkl
 
 .idea/*
 .DS_Store
+
+test/nlp/testtmp.py
+test/nlp/testtmpfl.py

--- a/flaml/automl.py
+++ b/flaml/automl.py
@@ -699,6 +699,16 @@ class AutoML(BaseEstimator):
         """Time taken to find best model in seconds."""
         return self.__dict__.get("_time_taken_best_iter")
 
+    def evaluate(self, X: pd.DataFrame, y: pd.Series, **eval_kwargs):
+        estimator = getattr(self, "_trained_estimator", None)
+        if estimator is None:
+            logger.warning(
+                "No estimator is trained. Please run fit with enough budget."
+            )
+            return None
+        X = self._preprocess(X)
+        return estimator.evaluate(X, y, **eval_kwargs)
+
     def predict(
         self,
         X: Union[np.array, pd.DataFrame, List[str], List[List[str]]],

--- a/flaml/nlp/utils.py
+++ b/flaml/nlp/utils.py
@@ -13,6 +13,18 @@ from ..data import (
     NLG_TASKS,
 )
 
+def load_default_checkpoint_path(task):
+    if task == SEQCLASSIFICATION:
+        return "google/electra-small-discriminator"
+    elif task == SEQREGRESSION:
+        return "google/electra-small-discriminator"
+    elif task == SUMMARIZATION:
+        return "t5-small"
+    elif task == MULTICHOICECLASSIFICATION:
+        return "google/electra-small-discriminator"
+    elif task == TOKENCLASSIFICATION:
+        return "google/electra-small-discriminator"
+
 
 def load_default_huggingface_metric_for_task(task):
 


### PR DESCRIPTION
proposing to add an evaluation function so the user can see the evaluation metric after retraining.

Currently after retraining the metric is not observable. However, if we use estimator.model.evaluate to evaluate, it's also inconvenient for the TransformersEstimator, because transformer's model.evaluate takes the tokenized Dataset as the input instead of the raw X_val, y_val, which means we have to again tokenize X_val, y_val in the user code. This is against the design for minimizing user code, so I think it's necessary to add this function. 