### PR TITLE
Fix AttributeError: readonly attribute for Python 3.10.4

### DIFF
--- a/flaml/default/estimator.py
+++ b/flaml/default/estimator.py
@@ -39,8 +39,8 @@ def flamlize_estimator(super_class, name: str, task: str, alternatives=None):
             self._params = params
             super().__init__(**params)
 
-        @wraps(super_class._get_param_names)
         @classmethod
+        @wraps(super_class._get_param_names)
         def _get_param_names(cls):
             return super_class._get_param_names()
 


### PR DESCRIPTION
Traceback:

```python
    from flaml.ml import sklearn_metric_loss_score
  File "/home/Jay/new_venv/lib/python3.10/site-packages/flaml/__init__.py", line 2, in <module>
    from flaml.automl import AutoML, logger_formatter
  File "/home/Jay/new_venv/lib/python3.10/site-packages/flaml/automl.py", line 52, in <module>
    from flaml.default.suggest import suggest_learner
  File "/home/Jay/new_venv/lib/python3.10/site-packages/flaml/default/__init__.py", line 8, in <module>
    from .estimator import (
  File "/home/Jay/new_venv/lib/python3.10/site-packages/flaml/default/estimator.py", line 153, in <module>
    RandomForestRegressor = flamlize_estimator(
  File "/home/Jay/new_venv/lib/python3.10/site-packages/flaml/default/estimator.py", line 30, in flamlize_estimator
    class EstimatorClass(super_class):
  File "/home/Jay/new_venv/lib/python3.10/site-packages/flaml/default/estimator.py", line 44, in EstimatorClass
    def _get_param_names(cls):
  File "/home/Jay/.pyenv/versions/3.10.4/lib/python3.10/functools.py", line 61, in update_wrapper
    wrapper.__wrapped__ = wrapped
AttributeError: readonly attribute

Process finished with exit code 1

```