### PR TITLE
fixing roberta add_prefix_space bug

### DIFF
--- a/flaml/model.py
+++ b/flaml/model.py
@@ -542,7 +542,11 @@ class TransformersEstimator(BaseEstimator):
             )
         else:
             return AutoTokenizer.from_pretrained(
-                self._training_args.model_path, use_fast=True
+                self._training_args.model_path,
+                use_fast=True,
+                add_prefix_space=True
+                if "roberta" in self._training_args.model_path
+                else False,
             )
 
     @property


### PR DESCRIPTION
adding add_prefix_space=True for roberta tokenizer, will fail otherwise.