### PR TITLE
solve issue #542. fix pickle.UnpickingError while blendsearch warm start

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "flaml/version.py")) as fp:
 __version__ = version["__version__"]
 
 install_requires = [
-    "NumPy>=1.16.2",
+    "NumPy>=1.17.0rc1",
     "lightgbm>=2.3.1",
     "xgboost>=0.90,<=1.3.3",
     "scipy>=1.4.1",


### PR DESCRIPTION
Issue I encountered:

#542 run test_restore.py and got _pickle.UnpicklingError: state is not a dictionary

I observed:

1. numpy version
  i. When numpy==1.16*, np.random.RandomState.__getstate__() returns a tuple, not a dict.
    _pickle.UnpicklingError occurs
  ii. When numpy>1.17.0rc1, it returns a dict;
    _pickle.UnpicklingError does not occur
  iii. When numpy>1.17.0rc1, flaml uses np_random_generator = np.random.Generator,
    _pickle.UnpicklingError does not occur

2. class _BackwardsCompatibleNumpyRng
  When I remove func _BackwardsCompatibleNumpyRng.__getattr__() , _pickle.UnpicklingError doesn't occur (regardless of numpy version == 1.16* or 1.17*)

To sum up,
I think making modifications to class _BackwardsCompatibleNumpyRng is not a good choice (_BackwardsCompatibleNumpyRng came from ray）and we still need to learn more about the operation mechanism of pickle.

So I upgraded the numpy version that flaml requires：
  setup.py："NumPy>=1.17.0rc1"