### PR TITLE
include .json file in flaml.default package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/FLAML",
     packages=setuptools.find_packages(include=["flaml*"]),
+    package_data={
+        "flaml.default": ["*/*.json"],
+    },
+    include_package_data=True,
     install_requires=install_requires,
     extras_require={
         "notebook": [


### PR DESCRIPTION
For using data-dependent default configurations, the .json files need to be included in the package.