### PR TITLE
Py36

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -59,20 +59,17 @@ setuptools.setup(
             "statsmodels>=0.12.2",
             "psutil==5.8.0",
             "dataclasses",
-            "transformers>=4.14",
+            "transformers[torch]>=4.14",
             "datasets",
-            "torch",
             "nltk",
             "rouge_score",
             "hcrystalball==0.1.10",
             "seqeval",
-            "protobuf<4",  # to prevent TypeError in ray
         ],
         "catboost": ["catboost>=0.26"],
         "blendsearch": ["optuna==2.8.0"],
         "ray": [
-            "ray[tune]~=1.10",
-            "protobuf<4",  # to prevent TypeError in ray
+            "ray[tune]~=1.13",
         ],
         "azureml": [
             "azureml-mlflow",
@@ -84,12 +81,11 @@ setuptools.setup(
             "vowpalwabbit",
         ],
         "nlp": [
-            "transformers>=4.14",
+            "transformers[torch]>=4.14",
             "datasets",
-            "torch",
-            "seqeval",
             "nltk",
             "rouge_score",
+            "seqeval",
         ],
         "ts_forecast": [
             "holidays<0.14",  # to prevent installation error for prophet

--- a/setup.py
+++ b/setup.py
@@ -110,5 +110,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
 )

--- a/test/nlp/test_autohf_tokenclassification.py
+++ b/test/nlp/test_autohf_tokenclassification.py
@@ -4,7 +4,10 @@ import requests
 from utils import get_toy_data_tokenclassification, get_automl_settings
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="do not run on mac os")
+@pytest.mark.skipif(
+    sys.platform == "darwin" or sys.version < "3.7",
+    reason="do not run on mac os or py<3.7",
+)
 def test_tokenclassification():
     from flaml import AutoML
 
@@ -13,7 +16,9 @@ def test_tokenclassification():
 
     automl_settings = get_automl_settings()
     automl_settings["task"] = "token-classification"
-    automl_settings["metric"] = "seqeval:overall_f1"  # evaluating based on the overall_f1 of seqeval
+    automl_settings[
+        "metric"
+    ] = "seqeval:overall_f1"  # evaluating based on the overall_f1 of seqeval
     automl_settings["fit_kwargs_by_estimator"]["transformer"]["label_list"] = [
         "O",
         "B-PER",


### PR DESCRIPTION
We will stop supporting python 3.6, but to give users time to migrate, allow package installation in 3.6 for now.