### PR TITLE
Fix SARIMAX seasonal_order parameter name in the wrapper

### DIFF
--- a/flaml/model.py
+++ b/flaml/model.py
@@ -1975,7 +1975,7 @@ class SARIMAX(ARIMA):
                 train_df[[TS_VALUE_COL]],
                 exog=train_df[regressors],
                 order=(self.params["p"], self.params["d"], self.params["q"]),
-                seasonality_order=(
+                seasonal_order=(
                     self.params["P"],
                     self.params["D"],
                     self.params["Q"],
@@ -1988,7 +1988,7 @@ class SARIMAX(ARIMA):
             model = SARIMAX_estimator(
                 train_df,
                 order=(self.params["p"], self.params["d"], self.params["q"]),
-                seasonality_order=(
+                seasonal_order=(
                     self.params["P"],
                     self.params["D"],
                     self.params["Q"],


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The SARIMAX wrapper passed the seasonal parameters as the `seasonality_order` keyword arg to the statsmodels SARIMAX implementation, whereas the [right name](https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html) is `seasonal_order`. 

As a result, the 4 seasonal order parameters were being ignored by the SARIMAX fitter altogether.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
