### PR TITLE
Issue724

### DIFF
--- a/flaml/nlp/huggingface/data_collator.py
+++ b/flaml/nlp/huggingface/data_collator.py
@@ -6,7 +6,12 @@ from transformers.data.data_collator import (
 )
 from collections import OrderedDict
 
-from flaml.data import TOKENCLASSIFICATION, MULTICHOICECLASSIFICATION, SUMMARIZATION
+from flaml.data import (
+    TOKENCLASSIFICATION,
+    MULTICHOICECLASSIFICATION,
+    SUMMARIZATION,
+    SEQCLASSIFICATION,
+)
 
 
 @dataclass
@@ -45,5 +50,6 @@ task_to_datacollator_class = OrderedDict(
         (TOKENCLASSIFICATION, DataCollatorForTokenClassification),
         (MULTICHOICECLASSIFICATION, DataCollatorForMultipleChoiceClassification),
         (SUMMARIZATION, DataCollatorForSeq2Seq),
+        (SEQCLASSIFICATION, DataCollatorWithPadding),
     ]
 )

--- a/test/nlp/test_autohf.py
+++ b/test/nlp/test_autohf.py
@@ -56,7 +56,7 @@ def test_hf_data():
         record_id=0,
         **automl_settings
     )
-    automl.predict(X_test)
+    automl.predict(X_test, **{"per_device_eval_batch_size": 2})
     automl.predict(["test test", "test test"])
     automl.predict(
         [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously in the NLP module, seq-classification uses the default data collator, so that when eval batch size > 1, a dimension mismatch error happens. Closes issue #724 
This PR fixes this bug by using DataCollatorWithPadding for seq-classification.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
