### PR TITLE
log search_state.config directly instead of under tag config

### DIFF
--- a/flaml/automl.py
+++ b/flaml/automl.py
@@ -3108,7 +3108,7 @@ class AutoML(BaseEstimator):
                 mlflow.log_metric("trial_time", search_state.trial_time)
                 mlflow.log_metric("wall_clock_time", self._state.time_from_start)
                 mlflow.log_metric("validation_loss", search_state.val_loss)
-                mlflow.log_param("config", search_state.config)
+                mlflow.log_params(search_state.config)
                 mlflow.log_param("learner", estimator)
                 mlflow.log_param("sample_size", search_state.sample_size)
                 mlflow.log_metric("best_validation_loss", search_state.best_loss)


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, FLAML logs a parameter called "config" with dictionary of all config parameters MLflow for each run, creating a "key-dictionary" pair. This makes further analysis using MLflow difficult, such as comparing runs, which is designed to compare key-value pairs. 

In this change, we propose logging the parameters directly to MLflow, rather than bundled into the "config" parameter. `best_config` will continue to be logged as a dict for consistency.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
