### PR TITLE
Signature bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
             "hcrystalball==0.1.10",
             "seqeval",
             "pytorch-forecasting>=0.9.0",
+            "vowpalwabbit>=8.10.0, <9.0.0",
         ],
         "catboost": ["catboost>=0.26"],
         "blendsearch": ["optuna==2.8.0"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There was an error when trying to use Flaml's `SKlearnEstimator` class with an sklearn estimator because this one didn't use an `n_jobs` argument. As a result I changed the behavior of the model class so that it issues a warning if something like this happens but adjusts the parameters passed to constructor so that it still functions. 

I am no sure this is the best approach but I would like to have some initial thoughts to see if others think this is a correct way of approaching it. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
"Closes #759 "
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

A short note on the checks. I ran the auto checks and the following 4 checks  failed when using the coverage argument but passed when running them individually:
```console
FAILED test/test_autovw.py::TestAutoVW::test_supervised_vw_tune_namespace - ImportError: To use AutoVW, please run pip install flaml[vw] to install vowpalwabbit
FAILED test/test_autovw.py::TestAutoVW::test_supervised_vw_tune_namespace_learningrate - ImportError: To use AutoVW, please run pip install flaml[vw] to install vowpalwabbit
FAILED test/test_autovw.py::TestAutoVW::test_vw_oml_problem_and_vanilla_vw - ModuleNotFoundError: No module named ‘vowpalwabbit’
FAILED test/automl/test_notebook_example.py::test_mlflow - ValueError: Cannot find a pickle file for dataset adult at location /home/vscode/.openml/cache/org/openml/www/datasets/1590/dataset.pkl.py3
```
