### PR TITLE
Indentation corrected

### DIFF
--- a/website/docs/Use-Cases/Task-Oriented-AutoML.md
+++ b/website/docs/Use-Cases/Task-Oriented-AutoML.md
@@ -573,7 +573,7 @@ The curve suggests that increasing the time budget may further improve the accur
 2. set t2 as the time budget, and also set `early_stop=True`. If the early stopping is triggered, you will see a warning like
 > WARNING - All estimator hyperparameters local search has converged at least once, and the total search time exceeds 10 times the time taken to find the best model.
 
-> WARNING - Stopping search as early_stop is set to True.
+ > WARNING - Stopping search as early_stop is set to True.
 
 ### How much time is needed to find the best model
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For improving the UI

<!-- Please give a short summary of the change and the problem this solves. -->

The two warning blockquotes in here:- `https://microsoft.github.io/FLAML/docs/Use-Cases/Task-Oriented-AutoML#how-to-set-time-budget` had misaligned indentation. I corrected it by adding a whitespace in beginning of the Second blockquote


## Related issue number

Closes #776 

## Checks

- [x ] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x ] I've made sure all auto checks have passed.
