### PR TITLE
Included hint to escape brackets for pip setup

### DIFF
--- a/website/docs/Contribute.md
+++ b/website/docs/Contribute.md
@@ -64,6 +64,8 @@ git clone https://github.com/microsoft/FLAML.git
 pip install -e FLAML[test,notebook]
 ```
 
+In case the `pip install` command fails, try escaping the brackets such as `pip install -e FLAML\[test,notebook\]`
+
 ### Docker
 
 We provide a simple [Dockerfile](https://github.com/microsoft/FLAML/blob/main/Dockerfile).


### PR DESCRIPTION
As described in #777, I had trouble executing the setup using zsh. Eventually, I noticed that I had to escape the brackets.

My proposed change includes both brackets to be escaped, however for me it was enough to escape the opening one only, since as far as I know a trailing non-escaped closing bracket will then be recognized, accordingly.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->
Read it!

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Change provides guidance for dev setup in case `pip install -e FLAML[]` fails, even though executed in correct order and dir:
====>>> Escape of Brackets à la `\]`

## Related issue number

@sonichi suggested PR in #777 

## Checks

most checks are not relevant for this

- [ ] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
