### PR TITLE
Removed extra | in documentation

### DIFF
--- a/website/docs/Use-Cases/Tune-User-Defined-Function.md
+++ b/website/docs/Use-Cases/Tune-User-Defined-Function.md
@@ -130,7 +130,6 @@ You can find the corresponding search space choice in the table below once you h
 | log scale      | tune.lograndint(lower: int, upper: int, base: float = 10 | tune.loguniform(lower: float, upper: float, base: float = 10)|
 | linear scale with quantization| tune.qrandint(lower: int, upper: int, q: int = 1)| tune.quniform(lower: float, upper: float, q: float = 1)|
 log scale with quantization  | tune.qlograndint(lower: int, upper, q: int = 1, base: float = 10)| tune.qloguniform(lower: float, upper, q: float = 1, base: float = 10)
-|
 
 
 See the example below for the commonly used types of domains.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To make the Documentation cleaner.
The Tune-User-Defined-Function doc(i.e https://microsoft.github.io/FLAML/docs/Use-Cases/Tune-User-Defined-Function#details-and-guidelines-on-hyperparameter-search-space) had an extra | after the table.
So I had removed the extra |.
## Related issue number

Closes #775 

## Screenshots
| Before |

<img width="1227" alt="Screenshot 2022-11-03 at 11 53 32 PM" src="https://user-images.githubusercontent.com/16017648/199803904-3b4c3878-2615-4cb3-81b6-fc8c5fc519b4.png">

| After | 

<img width="1224" alt="Screenshot 2022-11-03 at 11 52 23 PM" src="https://user-images.githubusercontent.com/16017648/199803663-f53cc824-f4a7-4591-9367-3b6e31af4e02.png">

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
