### PR TITLE
fixed the case where y_train is a series while X_train is a numpy array

### DIFF
--- a/flaml/automl.py
+++ b/flaml/automl.py
@@ -1273,8 +1273,8 @@ class AutoML(BaseEstimator):
                 )
             if self._df:
                 X_train_all.reset_index(drop=True, inplace=True)
-                if isinstance(y_train_all, pd.Series):
-                    y_train_all.reset_index(drop=True, inplace=True)
+            if isinstance(y_train_all, pd.Series):
+                y_train_all.reset_index(drop=True, inplace=True)
 
         X_train, y_train = X_train_all, y_train_all
         self._state.groups_all = self._state.groups


### PR DESCRIPTION
## Why are these changes needed?

To omit display of FutureWarning in cases where y_train is a Series.

## Related issue number

Closes #777 

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
