### PR TITLE
fix typo of output directory

### DIFF
--- a/test/nlp/test_autohf_regression.py
+++ b/test/nlp/test_autohf_regression.py
@@ -24,7 +24,7 @@ def test_regression():
     automl_settings["task"] = "seq-regression"
     automl_settings["metric"] = "pearsonr"
     automl_settings["starting_points"] = {"transformer": {"num_train_epochs": 1}}
-    automl_settings["use_ray"] = {"local_dir": "data/outut/"}
+    automl_settings["use_ray"] = {"local_dir": "data/output/"}
 
     ray.shutdown()
     ray.init()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is a typo of the output directory in the test function. Modifying it will make the code clearer.

## Related issue number

No.

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
