### PR TITLE
skip test_hf_data in py 3.6

### DIFF
--- a/test/nlp/test_autohf.py
+++ b/test/nlp/test_autohf.py
@@ -6,7 +6,10 @@ import os
 import shutil
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="do not run on mac os")
+@pytest.mark.skipif(
+    sys.platform == "darwin" or sys.version < "3.7",
+    reason="do not run on mac os or py<3.7",
+)
 def test_hf_data():
     from flaml import AutoML
 


### PR DESCRIPTION

## Why are these changes needed?

This [test error](https://github.com/microsoft/FLAML/actions/runs/3561619371/jobs/5993111781#step:11:146) blocks PR #828. 
Disabling this test on py 3.6

## Related issue number

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
