### PR TITLE
Fix example tune-pytorch where the checkpoint path may be named differently

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -2566,6 +2566,11 @@ class AutoML(BaseEstimator):
         self._use_ray = use_ray or n_concurrent_trials > 1
         # use the following condition if we have an estimation of average_trial_time and average_trial_overhead
         # self._use_ray = use_ray or n_concurrent_trials > ( average_trail_time + average_trial_overhead) / (average_trial_time)
+
+        # If no time_budget and no max_iter is specified, then effectively zero-shot AutoML is used. 
+        if time_budget is -1 and max_iter is None:
+            logger.info('Neither time_budegt nor max_iter is specified, zero-shot ML is used. ')
+
         if self._use_ray is not False:
             import ray
 

--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -2567,10 +2567,6 @@ class AutoML(BaseEstimator):
         # use the following condition if we have an estimation of average_trial_time and average_trial_overhead
         # self._use_ray = use_ray or n_concurrent_trials > ( average_trail_time + average_trial_overhead) / (average_trial_time)
 
-        # If no time_budget and no max_iter is specified, then effectively zero-shot AutoML is used. 
-        if time_budget is -1 and max_iter is None:
-            logger.info('Neither time_budegt nor max_iter is specified, zero-shot ML is used. ')
-
         if self._use_ray is not False:
             import ray
 

--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -2566,7 +2566,6 @@ class AutoML(BaseEstimator):
         self._use_ray = use_ray or n_concurrent_trials > 1
         # use the following condition if we have an estimation of average_trial_time and average_trial_overhead
         # self._use_ray = use_ray or n_concurrent_trials > ( average_trail_time + average_trial_overhead) / (average_trial_time)
-
         if self._use_ray is not False:
             import ray
 

--- a/notebook/tune_pytorch.ipynb
+++ b/notebook/tune_pytorch.ipynb
@@ -347,7 +347,11 @@
     "        best_trained_model = nn.DataParallel(best_trained_model)\n",
     "best_trained_model.to(device)\n",
     "\n",
-    "checkpoint_path = os.path.join(best_trial.checkpoint.value, \"checkpoint\")\n",
+    "checkpoint_value = (\n",
+    "    getattr(best_trial.checkpoint, \"dir_or_data\", None)\n",
+    "    or best_trial.checkpoint.value\n",
+    ")\n",
+    "checkpoint_path = os.path.join(checkpoint_value, \"checkpoint\")\n",
     "\n",
     "model_state, optimizer_state = torch.load(checkpoint_path)\n",
     "best_trained_model.load_state_dict(model_state)\n",
@@ -358,11 +362,9 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "f7771e6a3915580179405189f5aa4eb9047494cbe4e005b29b851351b54902f6"
-  },
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit ('venv': venv)",
+   "display_name": "Python 3.11.0 64-bit",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -375,11 +377,16 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.11.0"
   },
   "metadata": {
    "interpreter": {
     "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
    }
   }
  },

--- a/test/tune/test_pytorch_cifar10.py
+++ b/test/tune/test_pytorch_cifar10.py
@@ -313,7 +313,11 @@ def cifar10_main(
             best_trained_model = nn.DataParallel(best_trained_model)
     best_trained_model.to(device)
 
-    checkpoint_path = os.path.join(best_trial.checkpoint.value, "checkpoint")
+    checkpoint_value = (
+        getattr(best_trial.checkpoint, "dir_or_data", None)
+        or best_trial.checkpoint.value
+    )
+    checkpoint_path = os.path.join(checkpoint_value, "checkpoint")
 
     model_state, optimizer_state = torch.load(checkpoint_path)
     best_trained_model.load_state_dict(model_state)

--- a/website/docs/Examples/Tune-PyTorch.md
+++ b/website/docs/Examples/Tune-PyTorch.md
@@ -261,7 +261,8 @@ if torch.cuda.is_available():
         best_trained_model = nn.DataParallel(best_trained_model)
 best_trained_model.to(device)
 
-checkpoint_path = os.path.join(best_trial.checkpoint.value, "checkpoint")
+checkpoint_value = getattr(best_trial.checkpoint, "dir_or_data", None) or best_trial.checkpoint.value
+checkpoint_path = os.path.join(checkpoint_value, "checkpoint")
 
 model_state, optimizer_state = torch.load(checkpoint_path)
 best_trained_model.load_state_dict(model_state)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Following the Tune with Pytorch example (https://microsoft.github.io/FLAML/docs/Examples/Tune-PyTorch), the following line will give an error saying that the checkpoint has no attribute 'value'
checkpoint_path = os.path.join(best_trial.checkpoint.value, "checkpoint"). 
This is because that best_tria.checkpoint is a Trial object defined in ray.tune.experiment.trial . In the newer version of ray, the checkpoint value (the path) attribute is named 'dir_or_data'. See https://docs.ray.io/en/latest/_modules/ray/tune/experiment/trial.html for more info.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#852 

<!-- For example: "Closes #1234" -->

## Checks

- [x ] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ na] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x ] I've made sure all auto checks have passed.
