### PR TITLE
Do not persist entire AutoMLState in Searcher

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -491,7 +491,7 @@ class AutoMLState:
         return estimator, train_time
 
 
-def size(state: AutoMLState, config: dict) -> float:
+def size(learner_classes: dict, config: dict) -> float:
     """Size function.
 
     Returns:
@@ -499,7 +499,7 @@ def size(state: AutoMLState, config: dict) -> float:
     """
     config = config.get("ml", config)
     estimator = config["learner"]
-    learner_class = state.learner_classes.get(estimator)
+    learner_class = learner_classes.get(estimator)
     return learner_class.size(config)
 
 
@@ -3125,7 +3125,7 @@ class AutoML(BaseEstimator):
                 min_resource=min_resource_all_estimator,
                 max_resource=self.max_resource,
                 config_constraints=[
-                    (partial(size, self._state), "<=", self._mem_thres)
+                    (partial(size, self._state.learner_classes), "<=", self._mem_thres)
                 ],
                 metric_constraints=self.metric_constraints,
                 seed=self._seed,

--- a/test/automl/test_constraints.py
+++ b/test/automl/test_constraints.py
@@ -55,7 +55,9 @@ def test_metric_constraints():
         min_resource=automl.min_resource,
         max_resource=automl.max_resource,
         time_budget_s=automl._state.time_budget,
-        config_constraints=[(partial(size, automl._state), "<=", automl._mem_thres)],
+        config_constraints=[
+            (partial(size, automl._state.learner_classes), "<=", automl._mem_thres)
+        ],
         metric_constraints=automl.metric_constraints,
         num_samples=5,
     )
@@ -159,7 +161,9 @@ def test_metric_constraints_custom():
         min_resource=automl.min_resource,
         max_resource=automl.max_resource,
         time_budget_s=automl._state.time_budget,
-        config_constraints=[(partial(size, automl._state), "<=", automl._mem_thres)],
+        config_constraints=[
+            (partial(size, automl._state.learner_classes), "<=", automl._mem_thres)
+        ],
         metric_constraints=automl.metric_constraints,
         num_samples=5,
     )

--- a/test/automl/test_python_log.py
+++ b/test/automl/test_python_log.py
@@ -84,7 +84,11 @@ class TestLogging(unittest.TestCase):
                 min_resource=automl.min_resource,
                 max_resource=automl.max_resource,
                 config_constraints=[
-                    (partial(size, automl._state), "<=", automl._mem_thres)
+                    (
+                        partial(size, automl._state.learner_classes),
+                        "<=",
+                        automl._mem_thres,
+                    )
                 ],
                 metric_constraints=automl.metric_constraints,
             )

--- a/test/automl/test_xgboost2d.py
+++ b/test/automl/test_xgboost2d.py
@@ -77,7 +77,9 @@ def test_simple(method=None):
         min_resource=automl.min_resource,
         max_resource=automl.max_resource,
         time_budget_s=automl._state.time_budget,
-        config_constraints=[(partial(size, automl._state), "<=", automl._mem_thres)],
+        config_constraints=[
+            (partial(size, automl._state.learner_classes), "<=", automl._mem_thres)
+        ],
         metric_constraints=automl.metric_constraints,
         num_samples=5,
     )


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the entire `AutoMLState` is persisted in Searcher as a part of the `config_constraints`. As the State object contains the dataframe used, this means a large amount of data will be persisted to disk as a part of automatic Tune Experiment checkpointing, leading to large disk usage and high performance overhead, causing various bottlenecks.

This PR changes the `size` function used in `config_constraints` to only consider the `learner_classes` attribute of `AutoMLState` which removes the issue of too much data being saved.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/microsoft/FLAML/issues/866

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
