### PR TITLE
allow missing data for "ts_forecast_panel" task

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2250,6 +2250,8 @@ class TemporalFusionTransformerEstimator(SKLearnEstimator):
             variable_groups=kwargs.get(
                 "variable_groups", {}
             ),  # group of categorical variables can be treated as one variable
+            constant_fill_strategy=kwargs.get("constant_fill_strategy", {}),
+            allow_missing_timesteps=True,
             lags=kwargs.get("lags", {}),
             target_normalizer=GroupNormalizer(
                 groups=kwargs["group_ids"], transformation="softplus"

--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2346,7 +2346,7 @@ class TemporalFusionTransformerEstimator(SKLearnEstimator):
         fit_keys = ["period", "gpu_per_trial", "group_ids", "freq", "log_dir", "max_epochs", "batch_size",
                     "static_categoricals", "static_reals", "time_varying_known_categoricals", "time_varying_known_reals",
                     "time_varying_unknown_reals", "time_varying_unknown_categoricals", "variable_groups",
-                    "max_encoder_length", "min_encoder_length", "lags"]
+                    "max_encoder_length", "min_encoder_length", "lags", "constant_fill_strategy"]
         for key in fit_keys:
             if key in kwargs: kwargs.pop(key)
         trainer = _fit(log=False, **kwargs)


### PR DESCRIPTION
## Why are these changes needed?
- allow missing data for "ts_forecast_panel" task
- address typo for `hcrystalball_model`
- add test for missing data scenario in test_forecast.py

## Related issue number
- closes #754 #770 
- addresses part 1 of #771 
- closes #839 
