### PR TITLE
display data head in notebook; exclude None

### DIFF
--- a/flaml/tune/tune.py
+++ b/flaml/tune/tune.py
@@ -64,7 +64,11 @@ class ExperimentAnalysis(EA):
             return self.get_best_config(self.default_metric, self.default_mode)
 
     def lexico_best(self, trials):
-        results = {index: trial.last_result for index, trial in enumerate(trials)}
+        results = {
+            index: trial.last_result
+            for index, trial in enumerate(trials)
+            if trial.last_result
+        }
         metrics = self.lexico_objectives["metrics"]
         modes = self.lexico_objectives["modes"]
         f_best = {}

--- a/notebook/automl_classification.ipynb
+++ b/notebook/automl_classification.ipynb
@@ -72,6 +72,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train.head()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
@@ -1283,7 +1292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15 (main, Oct 26 2022, 03:47:43) \n[GCC 10.2.1 20210110]"
+   "version": "3.9.16 (main, Dec  8 2022, 02:40:11) \n[GCC 10.2.1 20210110]"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Why are these changes needed?

* display data head in one notebook (other notebook may consider similar changes).
* exclude None from results in lexico_best.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
