### PR TITLE
Fixed issues causing coverage test failures in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /home/flaml-dev/FLAML
 
 # Install FLAML (Note: extra components can be installed if needed)
 RUN pip install -e .[test,notebook]
+ENV PATH="$PATH:/home/flaml-dev/.local/bin"
 
 # Install precommit hooks
 RUN pre-commit install

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cd /home/flaml-dev && git clone https://github.com/microsoft/FLAML.git
 WORKDIR /home/flaml-dev/FLAML
 
 # Install FLAML (Note: extra components can be installed if needed)
-RUN pip install -e .[test,notebook]
+RUN pip install -e .[test,notebook,vw]
 ENV PATH="$PATH:/home/flaml-dev/.local/bin"
 
 # Install precommit hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cd /home/flaml-dev && git clone https://github.com/microsoft/FLAML.git
 WORKDIR /home/flaml-dev/FLAML
 
 # Install FLAML (Note: extra components can be installed if needed)
-RUN sudo pip install -e .[test,notebook]
+RUN pip install -e .[test,notebook]
 
 # Install precommit hooks
 RUN pre-commit install

--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,7 @@ setuptools.setup(
         "nni": [
             "nni",
         ],
-        "vw": [
-            "vowpalwabbit>=8.10.0, <9.0.0",
-        ],
+        "vw": ["vowpalwabbit>=8.10.0,<9.0.0"],
         "nlp": [
             "transformers[torch]==4.18",
             "datasets",

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
             "nbconvert",
             "nbformat",
             "ipykernel",
+            "vowpalwabbit>=8.10.0,<9.0.0",
         ],
         "catboost": ["catboost>=0.26"],
         "blendsearch": ["optuna==2.8.0"],

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setuptools.setup(
             "nbconvert",
             "nbformat",
             "ipykernel",
-            "vowpalwabbit>=8.10.0,<9.0.0",
         ],
         "catboost": ["catboost>=0.26"],
         "blendsearch": ["optuna==2.8.0"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When I ran the coverage test in a docker container built by the current dockerfile, the following tests failed:

1. `test/test_autovw.py` with outputs below:
```
===================================== short test summary info ======================================
FAILED test/test_autovw.py::TestAutoVW::test_supervised_vw_tune_namespace - ImportError: To use AutoVW, please run pip install flaml[vw] to install vowpalwabbit
FAILED test/test_autovw.py::TestAutoVW::test_supervised_vw_tune_namespace_learningrate - ImportError: To use AutoVW, please run pip install flaml[vw] to install vowpalwabbit
FAILED test/test_autovw.py::TestAutoVW::test_vw_oml_problem_and_vanilla_vw - ModuleNotFoundError: No module named 'vowpalwabbit'
```
Therefore, I added `vw` in line 27 of Dockerfile.

2. `test/automl/test_forecast.py` with outputs below:
```
_______________________________________ test_forecast_panel ________________________________________

budget = 5

    def test_forecast_panel(budget=5):
>       data, special_days = get_stalliion_data()

test/automl/test_forecast.py:485:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test/automl/test_forecast.py:448: in get_stalliion_data
    data = get_stallion_data()
/usr/local/lib/python3.7/site-packages/pytorch_forecasting/data/examples.py:50: in get_stallion_data
    fname = _get_data_by_filename("stallion.parquet")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

fname = 'stallion.parquet'

    def _get_data_by_filename(fname: str) -> Path:
        """
        Download file or used cached version.

        Args:
            fname (str): name of file to download

        Returns:
            Path: path at which file lives
        """
        full_fname = DATA_PATH.joinpath(fname)

        # check if file exists - download if necessary
        if not full_fname.exists():
            url = BASE_URL + fname
            download = requests.get(url, allow_redirects=True)
>           with open(full_fname, "wb") as file:
E           PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.7/site-packages/pytorch_forecasting/data/stallion.parquet'

/usr/local/lib/python3.7/site-packages/pytorch_forecasting/data/examples.py:31: PermissionError
```

The issue here is that the current Dockerfile calls `sudo pip install`, which installs the dependencies to a permission-restricted directory, causing the above error when trying to open a file from that directory. Therefore, I removed `sudo` from line 27 of Dockerfile and added the new installation directory to PATH.

After the above fixes, I rebuilt the docker container and the above failures have been resolved. Below is the output:
```
======================================= test session starts ========================================
platform linux -- Python 3.7.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /home/flaml-dev/FLAML, configfile: pytest.ini
plugins: anyio-3.6.2
collected 169 items / 1 deselected / 168 selected

test/test_autovw.py .....                                                                    [  2%]
test/test_gpu.py .                                                                           [  3%]
test/test_model.py ..                                                                        [  4%]
test/test_version.py .                                                                       [  5%]
test/automl/test_classification.py .........                                                 [ 10%]
test/automl/test_constraints.py ..                                                           [ 11%]
test/automl/test_custom_hp.py ..                                                             [ 13%]
test/automl/test_forecast.py .......                                                         [ 17%]
test/automl/test_multiclass.py ...............                                               [ 26%]
test/automl/test_notebook.py ss                                                              [ 27%]
test/automl/test_notebook_example.py ....                                                    [ 29%]
test/automl/test_python_log.py .                                                             [ 30%]
test/automl/test_regression.py ......                                                        [ 33%]
test/automl/test_score.py .....                                                              [ 36%]
test/automl/test_split.py ....                                                               [ 39%]
test/automl/test_training_log.py ...                                                         [ 41%]
test/automl/test_warmstart.py ...                                                            [ 42%]
test/automl/test_xgboost2d.py ....                                                           [ 45%]
test/default/test_defaults.py ............                                                   [ 52%]
test/nlp/test_autohf.py .                                                                    [ 52%]
test/nlp/test_autohf_classificationhead.py .........                                         [ 58%]
test/nlp/test_autohf_custom_metric.py .                                                      [ 58%]
test/nlp/test_autohf_cv.py .                                                                 [ 59%]
test/nlp/test_autohf_loadargs.py .                                                           [ 60%]
test/nlp/test_autohf_multichoice_classification.py .                                         [ 60%]
test/nlp/test_autohf_regression.py .                                                         [ 61%]
test/nlp/test_autohf_summarization.py .                                                      [ 61%]
test/nlp/test_autohf_tokenclassification.py ..                                               [ 63%]
test/nlp/test_default.py .....                                                               [ 66%]
test/spark/test_automl.py ..s.                                                               [ 68%]
test/spark/test_ensemble.py .                                                                [ 69%]
test/spark/test_exceptions.py ...                                                            [ 70%]
test/spark/test_multiclass.py ............                                                   [ 77%]
test/spark/test_notebook.py .                                                                [ 78%]
test/spark/test_performance.py ..                                                            [ 79%]
test/spark/test_tune.py .                                                                    [ 80%]
test/spark/test_utils.py ....                                                                [ 82%]
test/tune/test_constraints.py .                                                              [ 83%]
test/tune/test_flaml_raytune_consistency.py .                                                [ 83%]
test/tune/test_lexiflow.py ..                                                                [ 85%]
test/tune/test_record_incumbent.py .                                                         [ 85%]
test/tune/test_reproducibility.py ...                                                        [ 87%]
test/tune/test_restore.py ..                                                                 [ 88%]
test/tune/test_sample.py .                                                                   [ 89%]
test/tune/test_scheduler.py ......                                                           [ 92%]
test/tune/test_searcher.py ..                                                                [ 94%]
test/tune/test_searcher_invalid_values.py ..                                                 [ 95%]
test/tune/test_space.py ..                                                                   [ 96%]
test/tune/test_stop.py .                                                                     [ 97%]
test/tune/test_tune.py .....                                                                 [100%]
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
