### PR TITLE
Updated dict type args default value to None

### DIFF
--- a/flaml/automl/ml.py
+++ b/flaml/automl/ml.py
@@ -385,8 +385,10 @@ def _eval_estimator(
     obj,
     labels=None,
     log_training_metric=False,
-    fit_kwargs={},
+    fit_kwargs: Optional[dict] = None,
 ):
+    if fit_kwargs is None:
+        fit_kwargs = {}
     if isinstance(eval_metric, str):
         pred_start = time.time()
         val_pred_y = get_y_pred(estimator, X_val, eval_metric, obj)
@@ -445,9 +447,11 @@ def get_val_loss(
     labels=None,
     budget=None,
     log_training_metric=False,
-    fit_kwargs={},
+    fit_kwargs: Optional[dict] = None,
     free_mem_ratio=0,
 ):
+    if fit_kwargs is None:
+        fit_kwargs = {}
     start = time.time()
     # if groups_val is not None:
     #     fit_kwargs['groups_val'] = groups_val
@@ -507,9 +511,11 @@ def evaluate_model_CV(
     best_val_loss,
     cv_score_agg_func=None,
     log_training_metric=False,
-    fit_kwargs={},
+    fit_kwargs: Optional[dict] = None,
     free_mem_ratio=0,
 ):
+    if fit_kwargs is None:
+        fit_kwargs = {}
     if cv_score_agg_func is None:
         cv_score_agg_func = default_cv_score_agg_func
     start_time = time.time()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Default value of fit_kwargs sometimes were set to be `{}`, it would be better to set it to be `None` in the function signature and set it to be `{}` inside the function.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
