### PR TITLE
fix delete in TransformersEstimator, so to remove the ckpt not found warning in PR 940

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -732,10 +732,8 @@ class TransformersEstimator(BaseEstimator):
 
     def _delete_one_ckpt(self, ckpt_location):
         if self._use_ray is False:
-            try:
+            if os.path.exists(ckpt_location):
                 shutil.rmtree(ckpt_location)
-            except FileNotFoundError:
-                logger.warning("checkpoint {} not found".format(ckpt_location))
 
     def cleanup(self):
         super().cleanup()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addressing the issue of deleting directory warning in #940 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
