### PR TITLE
add timeout to openai create

### DIFF
--- a/flaml/integrations/oai/completion.py
+++ b/flaml/integrations/oai/completion.py
@@ -99,6 +99,8 @@ class Completion:
     retry_time = 10
     # fail a request after hitting RateLimitError for this many seconds
     retry_timeout = 60
+    # time out for request to openai server
+    request_timeout = 30
 
     openai_completion_class = not ERROR and openai.Completion
     _total_cost = 0
@@ -136,7 +138,9 @@ class Completion:
         start_time = time.time()
         while True:
             try:
-                response = openai_completion.create(**config)
+                response = openai_completion.create(
+                    request_timeout=cls.request_timeout, **config
+                )
                 cls._cache.set(key, response)
                 return response
             except (
@@ -678,7 +682,9 @@ class Completion:
         if use_cache:
             with diskcache.Cache(cls.cache_path) as cls._cache:
                 return cls._get_response(params)
-        return cls.openai_completion_class.create(**params)
+        return cls.openai_completion_class.create(
+            request_timeout=cls.request_timeout, **params
+        )
 
 
 class ChatCompletion(Completion):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`request_timeout` is the right parameter for controlling the request to openai server.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
