### PR TITLE
Expose feature and label transformer in automl.py

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -489,6 +489,16 @@ class AutoML(BaseEstimator):
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, "w") as f:
             json.dump(best, f)
+            
+    @property
+    def feature_transformer(self):
+        """Returns AutoML Transformer"""
+        return self._transformer
+    
+    @property
+    def label_transformer(self):
+        """Returns AutoML label transformer"""
+        return self._label_transformer
 
     @property
     def classes_(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Exposes additional field in AutoML to eliminate a call to "preprocess_and_suggest_hyperparams" as the transformers are already accessible through the object

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #979

## Checks

- [X] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR, or I've made sure [lint with flake8](https://github.com/microsoft/FLAML/blob/816a82a1155b4de4705b21a615ccdff67c6da379/.github/workflows/python-package.yml#L54-L59) output is two 0s.
- [X] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
