### PR TITLE
Fix catboost failure in mac-os python<3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
             "pre-commit",
             "torch",
             "torchvision",
-            "catboost>=0.26",
+            "catboost>=0.26,<1.2",
             "rgf-python",
             "optuna==2.8.0",
             "openml==0.10.2",
@@ -77,7 +77,7 @@ setuptools.setup(
             "ipykernel",
             "pytorch-lightning<1.9.1",  # test_forecast_panel
         ],
-        "catboost": ["catboost>=0.26"],
+        "catboost": ["catboost>=0.26,<1.2"],
         "blendsearch": ["optuna==2.8.0"],
         "ray": [
             "ray[tune]~=1.13",
@@ -118,7 +118,7 @@ setuptools.setup(
             "hcrystalball==0.1.10",
             "pytorch-forecasting>=0.9.0",
         ],
-        "benchmark": ["catboost>=0.26", "psutil==5.8.0", "xgboost==1.3.3"],
+        "benchmark": ["catboost>=0.26,<1.2", "psutil==5.8.0", "xgboost==1.3.3"],
         "openai": ["openai==0.27.4", "diskcache"],
         "autogen": ["openai==0.27.4", "diskcache", "docker"],
         "synapse": ["joblibspark>=0.5.0", "optuna==2.8.0", "pyspark>=3.2.0"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Catboost is updated to 1.2 a few hours ago, which made all new checks for python<3.9 on mac-os fail. 
For instance: https://github.com/microsoft/FLAML/actions/runs/4857507859/jobs/8658060262?pr=1015

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
