### PR TITLE
Catch AuthenticationError trying different configs

### DIFF
--- a/flaml/autogen/oai/completion.py
+++ b/flaml/autogen/oai/completion.py
@@ -17,7 +17,7 @@ try:
         InvalidRequestError,
         APIConnectionError,
         Timeout,
-        AuthenticationError
+        AuthenticationError,
     )
     from openai import Completion as openai_Completion
     import diskcache

--- a/flaml/autogen/oai/completion.py
+++ b/flaml/autogen/oai/completion.py
@@ -17,6 +17,7 @@ try:
         InvalidRequestError,
         APIConnectionError,
         Timeout,
+        AuthenticationError
     )
     from openai import Completion as openai_Completion
     import diskcache
@@ -745,7 +746,7 @@ class Completion(openai_Completion):
                     cls.retry_timeout = 0 if i < len(config_list) - 1 else retry_timeout
                     # retry_timeout = 0 to avoid retrying
                     return cls.create(context, use_cache, **base_config)
-                except (RateLimitError, Timeout):
+                except (AuthenticationError, RateLimitError, Timeout):
                     logger.info(f"failed with config {i}", exc_info=1)
                     if i == len(config_list) - 1:
                         raise


### PR DESCRIPTION
While trying different openai `config_list`, some
configs might be outdated (e.g., an API key is expired). In these cases, we don't want the program to crash. Instead, we might want to try other configs.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@sonichi  @qingyun-wu 

## Why are these changes needed?
While trying different openai `config_list`, some
configs might be outdated (e.g., an API key is expired). In these cases, we don't want the program to crash. Instead, we might want to try other configs.

<!-- Please give a short summary of the change and the problem this solves. -->
2-line change.
1. import authentication error
2. catch the error while iterating through the `config_list`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
