### PR TITLE
docs: 📝 Fix link to installation section in Task-Oriented-AutoML.md

### DIFF
--- a/website/docs/Use-Cases/Task-Oriented-AutoML.md
+++ b/website/docs/Use-Cases/Task-Oriented-AutoML.md
@@ -414,7 +414,7 @@ To do parallel tuning with Spark, install the `spark` and `blendsearch` options:
 pip install flaml[spark,blendsearch]>=1.1.0
 ```
 
-For more details about installing Spark, please refer to [Installation](../Installation#Distributed-tuning).
+For more details about installing Spark, please refer to [Installation](../Installation#distributed-tuning).
 
 An example of using Spark for parallel tuning is:
 ```python


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The documentation for [parallel tuning with Spark ](https://microsoft.github.io/FLAML/docs/Use-Cases/Task-Oriented-AutoML#parallel-tuning-with-spark)in Use Cases/Task Oriented AutoML contains a [broken link](https://microsoft.github.io/FLAML/docs/Installation#Distributed-tuning) to the Distributed tuning section in Installation docs. This PR fixes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
 
- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
