### PR TITLE
suppress warning message of pandas_on_spark to_spark

### DIFF
--- a/flaml/automl/spark/metrics.py
+++ b/flaml/automl/spark/metrics.py
@@ -54,6 +54,10 @@ def spark_metric_loss_score(
     Returns:
         float | the loss score. A lower value indicates a better model.
     """
+    import warnings
+
+    warnings.filterwarnings("ignore")
+
     label_col = "label"
     prediction_col = "prediction"
     kwargs = {}

--- a/flaml/automl/spark/utils.py
+++ b/flaml/automl/spark/utils.py
@@ -92,6 +92,10 @@ def train_test_split_pyspark(
         pyspark.sql.DataFrame/pandas_on_spark DataFrame | The train dataframe.
         pyspark.sql.DataFrame/pandas_on_spark DataFrame | The test dataframe.
     """
+    import warnings
+
+    warnings.filterwarnings("ignore")
+
     if isinstance(df, psDataFrame):
         df = df.to_spark(index_col=index_col)
 
@@ -156,6 +160,10 @@ def iloc_pandas_on_spark(
     index_col: Optional[str] = "tmp_index_col",
 ) -> Union[psDataFrame, psSeries]:
     """Get the rows of a pandas_on_spark dataframe/series by index."""
+    import warnings
+
+    warnings.filterwarnings("ignore")
+
     if isinstance(psdf, (DataFrame, Series)):
         return psdf.iloc[index]
     if isinstance(index, (int, slice)):
@@ -207,6 +215,10 @@ def spark_kFold(
     Returns:
         A list of (train, validation) DataFrames.
     """
+    import warnings
+
+    warnings.filterwarnings("ignore")
+
     if isinstance(dataset, psDataFrame):
         dataset = dataset.to_spark(index_col=index_col)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To suppress warning message of pandas_on_spark to_spark like below:
```
PandasAPIOnSparkAdviceWarning: If `index_col` is not specified for `to_spark`, the existing index is lost when converting to Spark DataFrame.
```
The warning message could appear many times during the AutoML/tuning process, which is annoying and unnecessary.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
