### PR TITLE
Fix pyspark tests in workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -76,8 +76,8 @@ jobs:
         if: matrix.python-version != '3.10'
         run: |
           pip install -e .[vw]
-      - name: Uninstall pyspark on python 3.8 or 3.9 for windows
-        if: matrix.python-version == '3.8' || matrix.python-version == '3.9' && matrix.os == 'windows-2019'
+      - name: Uninstall pyspark on (python 3.9) or (python 3.8 + windows)
+        if: matrix.python-version == '3.9' || (matrix.python-version == '3.8' && matrix.os == 'windows-2019')
         run: |
           # Uninstall pyspark to test env without pyspark
           pip uninstall -y pyspark


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We need to:
- Skip spark tests on windows-2019 with python 3.8 by uninstalling pyspark as there are some unknown issues with the VM envs.
- Test envs without pyspark for python 3.9 by uninstall pyspark on python 3.9.
- Test envs with older version of pyspark on Ubuntu with python 3.8.

So, we want the workflow:
- Uninstall pyspark on all OS with python 3.9
- Uninstall pyspark on windows-2019 with python 3.8

However, the current workflow will:
- Uninstall pyspark on all OS with python 3.8
- Uninstall pyspark on windows-2019 with python 3.9

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
