### PR TITLE
encode timeout msg in bytes

### DIFF
--- a/flaml/autogen/code_utils.py
+++ b/flaml/autogen/code_utils.py
@@ -260,7 +260,7 @@ def execute_code(
         container.remove()
         if original_filename is None:
             os.remove(filepath)
-        return 1, "Timeout", image
+        return 1, bytes("Timeout", "utf-8"), image
     # try:
     #     container.wait(timeout=timeout)
     # except (ReadTimeout, ConnectionError):

--- a/flaml/autogen/code_utils.py
+++ b/flaml/autogen/code_utils.py
@@ -13,6 +13,7 @@ from flaml.autogen import oai, DEFAULT_MODEL, FAST_MODEL
 CODE_BLOCK_PATTERN = r"```(\w*)\n(.*?)\n```"
 WORKING_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extensions")
 UNKNOWN = "unknown"
+TIMEOUT_MSG = bytes("Timeout", "utf-8")
 
 
 def infer_lang(code):
@@ -180,7 +181,6 @@ def execute_code(
     filepath = os.path.join(work_dir, filename)
     file_dir = os.path.dirname(filepath)
     os.makedirs(file_dir, exist_ok=True)
-
     if code is not None:
         with open(filepath, "w") as fout:
             fout.write(code)
@@ -202,7 +202,7 @@ def execute_code(
         except TimeoutError:
             if original_filename is None:
                 os.remove(filepath)
-            return 1, "Timeout", None
+            return 1, TIMEOUT_MSG, None
         if original_filename is None:
             os.remove(filepath)
         return result.returncode, result.stderr if result.returncode else result.stdout, None
@@ -260,7 +260,7 @@ def execute_code(
         container.remove()
         if original_filename is None:
             os.remove(filepath)
-        return 1, bytes("Timeout", "utf-8"), image
+        return 1, TIMEOUT_MSG, image
     # try:
     #     container.wait(timeout=timeout)
     # except (ReadTimeout, ConnectionError):

--- a/flaml/version.py
+++ b/flaml/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0rc1"
+__version__ = "2.0.0rc2"

--- a/test/autogen/test_code.py
+++ b/test/autogen/test_code.py
@@ -74,9 +74,9 @@ def test_execute_code():
     assert exit_code, msg
     # execute code which takes a long time
     exit_code, error, image = execute_code("import time; time.sleep(2)", timeout=1)
-    assert exit_code and error == "Timeout"
+    assert exit_code and error.decode() == "Timeout"
     exit_code, error, image = execute_code("import time; time.sleep(2)", timeout=1, use_docker=False)
-    assert exit_code and error == "Timeout" and image is None
+    assert exit_code and error.decode() == "Timeout" and image is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A simple fix to make sure the msg returned is always in bytes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
