### PR TITLE
Add log metric

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -2161,7 +2161,7 @@ class AutoML(BaseEstimator):
                 mlflow.log_param("best_config", search_state.best_config)
                 mlflow.log_param("best_learner", self._best_estimator)
                 mlflow.log_metric(
-                    self._state.error_metric if self._state.error_metric == "customized metric" else self._state.metric,
+                    self._state.metric if isinstance(self._state.metric, str) else self._state.error_metric,
                     1 - search_state.val_loss
                     if self._state.error_metric.startswith("1-")
                     else -search_state.val_loss

--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -1785,6 +1785,7 @@ class AutoML(BaseEstimator):
         else:
             error_metric = "customized metric"
         logger.info(f"Minimizing error metric: {error_metric}")
+        self._state.error_metric = error_metric
 
         is_spark_dataframe = isinstance(X_train, psDataFrame) or isinstance(dataframe, psDataFrame)
         estimator_list = task.default_estimator_list(estimator_list, is_spark_dataframe)
@@ -2159,6 +2160,14 @@ class AutoML(BaseEstimator):
                 mlflow.log_metric("best_validation_loss", search_state.best_loss)
                 mlflow.log_param("best_config", search_state.best_config)
                 mlflow.log_param("best_learner", self._best_estimator)
+                mlflow.log_metric(
+                    self._state.error_metric if self._state.error_metric == "customized metric" else self._state.metric,
+                    1 - search_state.val_loss
+                    if self._state.error_metric.startswith("1-")
+                    else -search_state.val_loss
+                    if self._state.error_metric.startswith("-")
+                    else search_state.val_loss,
+                )
 
     def _search_sequential(self):
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To log metric as discussed in the [discord message](https://discord.com/channels/1025786666260111483/1027756612871536730/1128660014404481096) 

> Hi <@1022910063620390932> quick question. I noticed  that when I set a metric to optimize for, flaml doesn't log that metric to mlflow (when I start an mlflow run I'm the flaml context). It seems like flaml always logs "best_validation_loss" - I think it's 1-metric (when the metric is "bigger=better"). 
> 
> Is there a way to get flaml to log the optimization metric with the correct name?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
