### PR TITLE
modify the python filename extraction

### DIFF
--- a/flaml/autogen/agent/user_proxy_agent.py
+++ b/flaml/autogen/agent/user_proxy_agent.py
@@ -91,7 +91,7 @@ class UserProxyAgent(Agent):
                 logs = logs.decode("utf-8")
             elif lang in ["python", "Python"]:
                 if code.startswith("# filename: "):
-                    filename = code[11 : code.find("\n")].strip()
+                    filename = code[11 : code.find(".py")].strip() + '.py'
                 else:
                     filename = None
                 exitcode, logs, image = execute_code(


### PR DESCRIPTION


## Why are these changes needed?

modify from 
`code[11 : code.find("\n")].strip()`
to 
`code[11 : code.find(".py")].strip() + '.py'`

otherwise, invalid python file name would cause issue in committing current docker

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
