### PR TITLE
Use decorator for "register_auto_reply"

### DIFF
--- a/flaml/autogen/agentchat/__init__.py
+++ b/flaml/autogen/agentchat/__init__.py
@@ -1,5 +1,5 @@
 from .agent import Agent
-from .responsive_agent import ResponsiveAgent
+from .responsive_agent import ResponsiveAgent, register_auto_reply
 from .assistant_agent import AssistantAgent
 from .user_proxy_agent import UserProxyAgent
 from .groupchat import GroupChatManager
@@ -7,6 +7,7 @@ from .groupchat import GroupChatManager
 __all__ = [
     "Agent",
     "ResponsiveAgent",
+    "register_auto_reply",
     "AssistantAgent",
     "UserProxyAgent",
     "GroupChatManager",

--- a/flaml/autogen/agentchat/contrib/math_user_proxy_agent.py
+++ b/flaml/autogen/agentchat/contrib/math_user_proxy_agent.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Extra, root_validator
 from typing import Any, Callable, Dict, List, Optional, Union
 from time import sleep
 
-from flaml.autogen.agentchat import Agent, UserProxyAgent
+from flaml.autogen.agentchat import Agent, UserProxyAgent, register_auto_reply
 from flaml.autogen.code_utils import UNKNOWN, extract_code, execute_code, infer_lang
 from flaml.autogen.math_utils import get_answer
 
@@ -165,7 +165,6 @@ class MathUserProxyAgent(UserProxyAgent):
             default_auto_reply=default_auto_reply,
             **kwargs,
         )
-        self.register_auto_reply(Agent, self._generate_math_reply, 1)
         # fixed var
         self._max_invalid_q_per_step = max_invalid_q_per_step
 
@@ -276,6 +275,7 @@ class MathUserProxyAgent(UserProxyAgent):
             is_success = False
         return output, is_success
 
+    @register_auto_reply(Agent, 1)
     def _generate_math_reply(
         self,
         messages: Optional[List[Dict]] = None,

--- a/flaml/autogen/agentchat/groupchat.py
+++ b/flaml/autogen/agentchat/groupchat.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Dict, List, Optional, Union
 from .agent import Agent
-from .responsive_agent import ResponsiveAgent
+from .responsive_agent import ResponsiveAgent, register_auto_reply
 
 
 class GroupChatManager(ResponsiveAgent):
@@ -35,12 +35,12 @@ Then select the next role from {self._agent_names} to play. Only return the role
             human_input_mode=human_input_mode,
             **kwargs,
         )
-        self.register_auto_reply(Agent, self._generate_reply_for_participant)
         self.max_round = max_round
         self._agent_names = []
         self._messages = []
         # self._random = random.Random(seed)
 
+    @register_auto_reply(Agent)
     def _generate_reply_for_participant(
         self,
         messages: Optional[List[Dict]] = None,

--- a/flaml/autogen/agentchat/responsive_agent.py
+++ b/flaml/autogen/agentchat/responsive_agent.py
@@ -12,6 +12,7 @@ except ImportError:
     def colored(x, *args, **kwargs):
         return x
 
+
 def register_auto_reply(class_type, position=0):
     """Register a class-specific reply function.
     We achieve this by decorate the function with _regster_for and _insert_pos attributes.
@@ -26,11 +27,14 @@ def register_auto_reply(class_type, position=0):
         class_type (Class): the class type.
         position (int): the position of the reply function in the reply function list.
     """
+
     def decorator(reply_func):
         reply_func._registered_for = class_type
         reply_func._insert_pos = position
         return reply_func
+
     return decorator
+
 
 class ResponsiveAgent(Agent):
     """(Experimental) A class for generic responsive agents which can be configured as assistant or user proxy.
@@ -132,12 +136,8 @@ class ResponsiveAgent(Agent):
 
         # Handle class-specific reply defined in the "register_auto_reply" decorator.
         for name, method in vars(type(self)).items():
-            if hasattr(method, '_registered_for') and hasattr(method, '_insert_pos'):
+            if hasattr(method, "_registered_for") and hasattr(method, "_insert_pos"):
                 self._class_specific_reply.insert(method._insert_pos, (method._registered_for, method))
-
-
-
-
 
     @property
     def system_message(self):
@@ -556,7 +556,7 @@ class ResponsiveAgent(Agent):
                 if isinstance(sender, class_specifc_reply[0]) and (
                     not exclude or class_specifc_reply[1] not in exclude
                 ):
-                    final, reply = class_specifc_reply[1](messages, sender)
+                    final, reply = class_specifc_reply[1](self, messages, sender)
                     if final:
                         return reply
         return self._default_auto_reply

--- a/flaml/autogen/agentchat/responsive_agent.py
+++ b/flaml/autogen/agentchat/responsive_agent.py
@@ -135,9 +135,10 @@ class ResponsiveAgent(Agent):
         self.reply_at_receive = defaultdict(bool)
 
         # Handle class-specific reply defined in the "register_auto_reply" decorator.
-        for name, method in vars(type(self)).items():
-            if hasattr(method, "_registered_for") and hasattr(method, "_insert_pos"):
-                self._class_specific_reply.insert(method._insert_pos, (method._registered_for, method))
+        for cls in reversed(type(self).__mro__):  # loop all supers
+            for name, method in vars(cls).items():  # loop all functions
+                if hasattr(method, "_registered_for") and hasattr(method, "_insert_pos"):
+                    self._class_specific_reply.insert(method._insert_pos, (method._registered_for, method))
 
     @property
     def system_message(self):

--- a/flaml/autogen/agentchat/responsive_agent.py
+++ b/flaml/autogen/agentchat/responsive_agent.py
@@ -15,7 +15,7 @@ except ImportError:
 
 def register_auto_reply(class_type, position=0):
     """Register a class-specific reply function.
-    We achieve this by decorate the function with _regster_for and _insert_pos attributes.
+    We achieve this by decorating the function with _regster_for and _insert_pos attributes.
 
     The class-specific reply function will be called when the sender is an instance of the class_type.
     The function registered later will be checked earlier by default.
@@ -26,6 +26,9 @@ def register_auto_reply(class_type, position=0):
     Args:
         class_type (Class): the class type.
         position (int): the position of the reply function in the reply function list.
+
+    Returns:
+        callable: the decorated reply function.
     """
 
     def decorator(reply_func):
@@ -135,10 +138,14 @@ class ResponsiveAgent(Agent):
         self.reply_at_receive = defaultdict(bool)
 
         # Handle class-specific reply defined in the "register_auto_reply" decorator.
+        _registered = []  # avoid registering the same function twice
         for cls in reversed(type(self).__mro__):  # loop all supers
             for name, method in vars(cls).items():  # loop all functions
+                if method in _registered:
+                    continue  # already added
                 if hasattr(method, "_registered_for") and hasattr(method, "_insert_pos"):
                     self._class_specific_reply.insert(method._insert_pos, (method._registered_for, method))
+                    _registered.append(method)
 
     @property
     def system_message(self):
@@ -710,3 +717,6 @@ class ResponsiveAgent(Agent):
             function_map: a dictionary mapping function names to functions.
         """
         self._function_map.update(function_map)
+
+
+agent = ResponsiveAgent("xyz")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Use decorator to simply the auto reply function registration.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
