### PR TITLE
Provide initial values to `exitcode`, `exitcode2str` and `logs`

### DIFF
--- a/flaml/autogen/agentchat/conversable_agent.py
+++ b/flaml/autogen/agentchat/conversable_agent.py
@@ -611,6 +611,11 @@ class ConversableAgent(Agent):
         if messages is None:
             messages = self._oai_messages[sender]
         last_n_messages = code_execution_config.pop("last_n_messages", 1)
+        
+        logs = ""
+        exitcode = 0
+        exitcode2str = "execution succeeded"
+        
         for i in range(min(len(messages), last_n_messages)):
             message = messages[-(i + 1)]
             code_blocks = extract_code(message["content"])


### PR DESCRIPTION
When using `gpt-3.5-turbo-1106` i got the error bellow

```console
User_Proxy (to chat_manager):

Find a latest paper about gpt-4 on arxiv and find its potential applications in software

--------------------------------------------------------------------------------

>>>>>>>> USING AUTO REPLY...
Traceback (most recent call last):
  File "/home/marcos_souza/Projects/auto-gen/2/./main.py", line 46, in <module>
    user_proxy.initiate_chat(
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/conversable_agent.py", line 521, in initiate_chat
    self.send(self.generate_init_message(**context), recipient, silent=silent)
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/conversable_agent.py", line 324, in send
    recipient.receive(message, self, request_reply, silent)
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/conversable_agent.py", line 452, in receive
    reply = self.generate_reply(messages=self.chat_messages[sender], sender=sender)
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/conversable_agent.py", line 767, in generate_reply
    final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/groupchat.py", line 118, in run_chat
    reply = speaker.generate_reply(sender=self)
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/conversable_agent.py", line 767, in generate_reply
    final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])
  File "/home/marcos_souza/.local/lib/python3.10/site-packages/flaml/autogen/agentchat/conversable_agent.py", line 635, in generate_code_execution_reply
    return True, f"exitcode: {exitcode} ({exitcode2str})\nCode output: {logs}"
UnboundLocalError: local variable 'exitcode' referenced before assignment
```

This happens because the `logs`, `exitcode` and `exitcode2str` does not have an "initial value", so, when we not have messages no code is executed and the `exitcode`, `logs` and `exitcode2str` is not initiated, so, the code breaks as we can see above.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
