### PR TITLE
features: Manually setting the validation set for multi-output task

### DIFF
--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -230,5 +230,28 @@ def test_multioutput():
     print(model.predict(X_test))
 
 
+def test_multioutput_train_size():
+    import numpy as np
+    from sklearn.datasets import make_regression
+    from sklearn.model_selection import train_test_split
+    from sklearn.multioutput import MultiOutputRegressor, RegressorChain
+
+    # create regression data
+    X, y = make_regression(n_targets=3)
+
+    # split into train and test data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.20, random_state=42)
+    X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=0.1, random_state=42)
+
+    # train the model
+    model = MultiOutputRegressor(
+        AutoML(task="regression", time_budget=1, eval_method="holdout", multioutput_train_size=len(X_train))
+    )
+    model.fit(np.concatenate([X_train, X_val], axis=0), np.concatenate([y_train, y_val], axis=0))
+
+    # predict
+    print(model.predict(X_test))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
For original multi-output tasks where the eval_method is holdout, manual setting of the validation set was not possible. This commit introduces a new feature allowing manual setting of the validation set for multi-output tasks.
```python
model = MultiOutputRegressor(
    AutoML(
        task="regression",
        time_budget=1,
        eval_method="holdout",
        multioutput_train_size=len(X_train)
    )
)
model.fit(
    pd.concat([X_train, X_val]),
    pd.concat([y_train, y_val])
)
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->

- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
