### PR TITLE
Fix missing argument in StratifiedKFold.split()

### DIFF
--- a/flaml/automl/task/generic_task.py
+++ b/flaml/automl/task/generic_task.py
@@ -414,9 +414,7 @@ class GenericTask(Task):
                     sample_weight_full,
                     random_state=RANDOM_SEED,
                 )
-                state.fit_kwargs[
-                    "sample_weight"
-                ] = (
+                state.fit_kwargs["sample_weight"] = (
                     state.sample_weight_all
                 )  # NOTE: _prepare_data is before kwargs is updated to fit_kwargs_by_estimator
                 if isinstance(state.sample_weight_all, pd.Series):
@@ -501,9 +499,7 @@ class GenericTask(Task):
                 y_rest = (
                     y_train_all[rest]
                     if isinstance(y_train_all, np.ndarray)
-                    else iloc_pandas_on_spark(y_train_all, rest)
-                    if is_spark_dataframe
-                    else y_train_all.iloc[rest]
+                    else iloc_pandas_on_spark(y_train_all, rest) if is_spark_dataframe else y_train_all.iloc[rest]
                 )
                 stratify = y_rest if split_type == "stratified" else None
                 X_train, X_val, y_train, y_val = self._train_test_split(
@@ -619,9 +615,11 @@ class GenericTask(Task):
                 X = pd.DataFrame(
                     dict(
                         [
-                            (transformer._str_columns[idx], X[idx])
-                            if isinstance(X[0], List)
-                            else (transformer._str_columns[idx], [X[idx]])
+                            (
+                                (transformer._str_columns[idx], X[idx])
+                                if isinstance(X[0], List)
+                                else (transformer._str_columns[idx], [X[idx]])
+                            )
                             for idx in range(len(X))
                         ]
                     )
@@ -701,7 +699,7 @@ class GenericTask(Task):
             elif isinstance(kf, TimeSeriesSplit):
                 kf = kf.split(X_train_split, y_train_split)
             else:
-                kf = kf.split(X_train_split)
+                kf = kf.split(X_train_split, y_train_split)
 
         for train_index, val_index in kf:
             if shuffle:


### PR DESCRIPTION
In the `evaluate_model_CV` method of the `generic_task.py` module, the `StratifiedKFold.split()` method was missing a required positional argument 'y'. This caused a TypeError when attempting to split the dataset for cross-validation.

To address this issue #1303, I added the missing 'y' argument to the `StratifiedKFold.split()` method call. The corrected line of code now reads:

```python
kf = kf.split(X_train_split, y_train_split)
```

This modification ensures that the StratifiedKFold cross-validation splits the dataset correctly, allowing the AutoML fit method to run without encountering errors.

This fix resolves the issue reported in the FLAML library when using custom StratifiedKFold cross-validation.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->

- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
