### PR TITLE
Add logging import and logger initialization in spark module

### DIFF
--- a/flaml/automl/spark/__init__.py
+++ b/flaml/automl/spark/__init__.py
@@ -11,6 +11,9 @@ try:
     from pyspark.pandas import set_option
     from pyspark.sql import DataFrame as sparkDataFrame
     from pyspark.util import VersionUtils
+    import logging
+
+    logger = logging.getLogger(__name__)
 except ImportError:
 
     class psDataFrame:
@@ -31,4 +34,5 @@ try:
     import pandas as pd
     from pandas import DataFrame, Series
 except ImportError:
+    logger.warning("Pandas is not installed. Please install pandas to use DataFrame and Series functionalities.")
     DataFrame = Series = pd = None


### PR DESCRIPTION
This pull request adds an import statement for the logging module and initializes a logger object in the spark module of FLAML. The logger is used to issue a warning message if pandas is not installed. This ensures that users are notified if they attempt to use DataFrame and Series functionalities without having pandas installed, providing them with guidance on resolving the issue.

## Why are these changes needed?

This change is necessary to improve user experience by providing clear and informative warning messages when pandas is not installed. It helps users understand why certain functionalities may not work as expected and guides them on how to resolve the issue.

## Related issue number

#1262