### PR TITLE
Fix shuffle not defined

### DIFF
--- a/flaml/automl/task/generic_task.py
+++ b/flaml/automl/task/generic_task.py
@@ -3,7 +3,7 @@ import time
 from typing import List, Optional
 
 import numpy as np
-
+from random import shuffle
 from flaml.automl.data import TS_TIMESTAMP_COL, concat
 from flaml.automl.ml import EstimatorSubclass, default_cv_score_agg_func, get_val_loss
 from flaml.automl.spark import pd, ps, psDataFrame, psSeries
@@ -414,9 +414,7 @@ class GenericTask(Task):
                     sample_weight_full,
                     random_state=RANDOM_SEED,
                 )
-                state.fit_kwargs[
-                    "sample_weight"
-                ] = (
+                state.fit_kwargs["sample_weight"] = (
                     state.sample_weight_all
                 )  # NOTE: _prepare_data is before kwargs is updated to fit_kwargs_by_estimator
                 if isinstance(state.sample_weight_all, pd.Series):
@@ -501,9 +499,7 @@ class GenericTask(Task):
                 y_rest = (
                     y_train_all[rest]
                     if isinstance(y_train_all, np.ndarray)
-                    else iloc_pandas_on_spark(y_train_all, rest)
-                    if is_spark_dataframe
-                    else y_train_all.iloc[rest]
+                    else iloc_pandas_on_spark(y_train_all, rest) if is_spark_dataframe else y_train_all.iloc[rest]
                 )
                 stratify = y_rest if split_type == "stratified" else None
                 X_train, X_val, y_train, y_val = self._train_test_split(
@@ -619,9 +615,11 @@ class GenericTask(Task):
                 X = pd.DataFrame(
                     dict(
                         [
-                            (transformer._str_columns[idx], X[idx])
-                            if isinstance(X[0], List)
-                            else (transformer._str_columns[idx], [X[idx]])
+                            (
+                                (transformer._str_columns[idx], X[idx])
+                                if isinstance(X[0], List)
+                                else (transformer._str_columns[idx], [X[idx]])
+                            )
                             for idx in range(len(X))
                         ]
                     )

--- a/flaml/automl/task/generic_task.py
+++ b/flaml/automl/task/generic_task.py
@@ -3,7 +3,7 @@ import time
 from typing import List, Optional
 
 import numpy as np
-from random import shuffle
+from sklearn.utils import shuffle
 from flaml.automl.data import TS_TIMESTAMP_COL, concat
 from flaml.automl.ml import EstimatorSubclass, default_cv_score_agg_func, get_val_loss
 from flaml.automl.spark import pd, ps, psDataFrame, psSeries


### PR DESCRIPTION
This PR addresses the NameError encountered due to the missing import of the 'shuffle' function in the `generic_task.py` file.

Changes made:
- Imported `shuffle` from `sklearn.utils` to ensure proper functionality in the data preparation step.

Error message:
> File "/xxx/python3.8/site-packages/flaml/automl/task/generic_task.py", line 425, in prepare_data
X_train_all, y_train_all = shuffle(X_train_all, y_train_all, random_state=RANDOM_SEED) NameError: name 'shuffle' is not defined

With this fix, the data shuffling step will execute correctly without raising a NameError.

Closes #1308

## Why are these changes needed?

This change resolves a `NameError` that occurs due to the missing import of the `shuffle` function. By importing `shuffle` from `sklearn.utils`, we ensure that the data preparation step involving shuffling executes correctly, preventing runtime errors and improving the stability of the code.

## Related issue number

Closes #1308

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See [documentation](https://microsoft.github.io/FLAML/docs/Contribute#documentation) to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.