### PR TITLE
Don't pass `callbacks=None` to `XGBoostSklearnEstimator._fit`

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -1418,12 +1418,10 @@ class LGBMEstimator(BaseEstimator):
                     # since xgboost>=1.6.0, callbacks can't be passed in fit()
                     self.params["callbacks"] = callbacks
                     callbacks = None
-            self._fit(
-                X_train,
-                y_train,
-                callbacks=callbacks,
-                **kwargs,
-            )
+            if callbacks is None:
+                self._fit(X_train, y_train, **kwargs)
+            else:
+                self._fit(X_train, y_train, callbacks=callbacks, **kwargs)
             if callbacks is None:
                 # for xgboost>=1.6.0, pop callbacks to enable pickle
                 callbacks = self.params.pop("callbacks")

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     extras_require={
         "automl": [
             "lightgbm>=2.3.1",
-            "xgboost>=0.90,<2.0.0",
+            "xgboost>=0.90,<3.0.0",
             "scipy>=1.4.1",
             "pandas>=1.1.4",
             "scikit-learn>=0.24",


### PR DESCRIPTION
## Why are these changes needed?

The original implmentation would pass `callbacks=None` to `XGBoostSklearnEstimator._fit` and eventually lead to a `TypeError` of `XGBModel.fit() got an unexpected keyword argument 'callbacks'`. This PR instead does not pass the `callbacks=None` parameter to avoid the error.

## Related issue number

This PR fixes #1314

## Checks

<!-- - I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks). -->

- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
