### PR TITLE
test: Adding tests to verify model reproducibility

### DIFF
--- a/test/automl/test_classification.py
+++ b/test/automl/test_classification.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime
 from test.conftest import evaluate_cv_folds_with_underlying_model
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -457,7 +458,7 @@ def test_reproducibility_of_classification_models(estimator: str):
         "n_splits": 10,
         "metric": "f1",
         "keep_search_state": True,
-        "skip_transform":True
+        "skip_transform": True,
     }
     X, y = load_breast_cancer(return_X_y=True, as_frame=True)
     automl.fit(X_train=X, y_train=y, **automl_settings)
@@ -499,18 +500,16 @@ def test_reproducibility_of_classification_models(estimator: str):
         "xgb_limitdepth",
     ],
 )
-def test_reproducibility_of_underlying_classification_models(
-    estimator: str
-):
+def test_reproducibility_of_underlying_classification_models(estimator: str):
     """FLAML finds the best model for a given dataset, which it then provides to users.
 
     However, there are reported issues where FLAML was providing an incorrect model - see here:
     https://github.com/microsoft/FLAML/issues/1317
     FLAML defines FLAMLised models, which wrap around the underlying (SKLearn/XGBoost/CatBoost) model.
     Ideally, FLAMLised models should perform identically to the underlying model, when fitted
-    to the same data, with no budget. This verifies that this is the case for classification models. 
+    to the same data, with no budget. This verifies that this is the case for classification models.
     In this test we take the best model which FLAML provided us, extract the underlying model,
-     before retraining and testing it on the same folds - to verify that the result is reproducible. 
+     before retraining and testing it on the same folds - to verify that the result is reproducible.
     """
     automl = AutoML()
     automl_settings = {
@@ -522,19 +521,21 @@ def test_reproducibility_of_underlying_classification_models(
         "eval_method": "cv",
         "n_splits": 10,
         "metric": "f1",
-        "keep_search_state":True,
-        "skip_transform":True
+        "keep_search_state": True,
+        "skip_transform": True,
     }
     X, y = load_breast_cancer(return_X_y=True, as_frame=True)
     automl.fit(X_train=X, y_train=y, **automl_settings)
     best_model = automl.model
     assert best_model is not None
     val_loss_flaml = automl.best_result["val_loss"]
-    reproduced_val_loss_underlying_model = np.mean(evaluate_cv_folds_with_underlying_model(automl._state.X_train_all, 
-                                                        automl._state.y_train_all, automl._state.kf,
-                                                                                     best_model.model, 'classification'))
-    
-    assert pytest.approx(val_loss_flaml)  == reproduced_val_loss_underlying_model
+    reproduced_val_loss_underlying_model = np.mean(
+        evaluate_cv_folds_with_underlying_model(
+            automl._state.X_train_all, automl._state.y_train_all, automl._state.kf, best_model.model, "classification"
+        )
+    )
+
+    assert pytest.approx(val_loss_flaml) == reproduced_val_loss_underlying_model
 
 
 if __name__ == "__main__":

--- a/test/automl/test_classification.py
+++ b/test/automl/test_classification.py
@@ -1,28 +1,17 @@
 import unittest
 from datetime import datetime
-from typing import Any, Dict, List, Union
-
+from test.conftest import evaluate_cv_folds_with_underlying_model
 import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse
-from catboost import CatBoostClassifier, CatBoostRegressor, Pool
 from sklearn.datasets import load_breast_cancer
-from sklearn.metrics import f1_score
 from sklearn.model_selection import (
-    GroupKFold,
-    RepeatedStratifiedKFold,
-    StratifiedGroupKFold,
-    TimeSeriesSplit,
     train_test_split,
 )
 
 from flaml import AutoML, tune
-from flaml.automl.ml import default_cv_score_agg_func, get_val_loss
 from flaml.automl.model import LGBMEstimator
-from flaml.automl.spark import psDataFrame
-from flaml.automl.spark.utils import len_labels
-from flaml.config import RANDOM_SEED
 
 
 class MyLargeLGBM(LGBMEstimator):
@@ -459,15 +448,16 @@ def test_reproducibility_of_classification_models(estimator: str):
     """
     automl = AutoML()
     automl_settings = {
-        "max_iter": 2,
+        "max_iter": 5,
         "time_budget": -1,
         "task": "classification",
         "n_jobs": 1,
         "estimator_list": [estimator],
         "eval_method": "cv",
-        "n_splits": 3,
+        "n_splits": 10,
         "metric": "f1",
         "keep_search_state": True,
+        "skip_transform":True
     }
     X, y = load_breast_cancer(return_X_y=True, as_frame=True)
     automl.fit(X_train=X, y_train=y, **automl_settings)
@@ -492,6 +482,59 @@ def test_reproducibility_of_classification_models(estimator: str):
         free_mem_ratio=0,
     )
     assert pytest.approx(val_loss_flaml) == reproduced_val_loss
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        # "catboost",
+        "extra_tree",
+        "histgb",
+        "kneighbor",
+        # "lgbm",
+        # "lrl1",
+        "lrl2",
+        "rf",
+        "xgboost",
+        "xgb_limitdepth",
+    ],
+)
+def test_reproducibility_of_underlying_classification_models(
+    estimator: str
+):
+    """FLAML finds the best model for a given dataset, which it then provides to users.
+
+    However, there are reported issues where FLAML was providing an incorrect model - see here:
+    https://github.com/microsoft/FLAML/issues/1317
+    FLAML defines FLAMLised models, which wrap around the underlying (SKLearn/XGBoost/CatBoost) model.
+    Ideally, FLAMLised models should perform identically to the underlying model, when fitted
+    to the same data, with no budget. This verifies that this is the case for classification models. 
+    In this test we take the best model which FLAML provided us, extract the underlying model,
+     before retraining and testing it on the same folds - to verify that the result is reproducible. 
+    """
+    automl = AutoML()
+    automl_settings = {
+        "max_iter": 5,
+        "time_budget": -1,
+        "task": "classification",
+        "n_jobs": 1,
+        "estimator_list": [estimator],
+        "eval_method": "cv",
+        "n_splits": 10,
+        "metric": "f1",
+        "keep_search_state":True,
+        "skip_transform":True
+    }
+    X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+    automl.fit(X_train=X, y_train=y, **automl_settings)
+    best_model = automl.model
+    assert best_model is not None
+    val_loss_flaml = automl.best_result["val_loss"]
+    reproduced_val_loss_underlying_model = np.mean(evaluate_cv_folds_with_underlying_model(automl._state.X_train_all, 
+                                                        automl._state.y_train_all, automl._state.kf,
+                                                                                     best_model.model, 'classification'))
+    
+    assert pytest.approx(val_loss_flaml)  == reproduced_val_loss_underlying_model
 
 
 if __name__ == "__main__":

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -1,9 +1,11 @@
 import unittest
 
 import numpy as np
+import pytest
 import scipy.sparse
 from sklearn.datasets import (
     fetch_california_housing,
+    make_regression,
 )
 
 from flaml import AutoML
@@ -205,7 +207,6 @@ class TestRegression(unittest.TestCase):
 
 
 def test_multioutput():
-    from sklearn.datasets import make_regression
     from sklearn.model_selection import train_test_split
     from sklearn.multioutput import MultiOutputRegressor, RegressorChain
 
@@ -228,6 +229,64 @@ def test_multioutput():
 
     # predict
     print(model.predict(X_test))
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        # "catboost",
+        "extra_tree",
+        "histgb",
+        "kneighbor",
+        "lgbm",
+        "rf",
+        "xgboost",
+        "xgb_limitdepth",
+    ],
+)
+def test_reproducibility_of_regression_models(estimator: str):
+    """FLAML finds the best model for a given dataset, which it then provides to users.
+
+    However, there are reported issues where FLAML was providing an incorrect model - see here:
+    https://github.com/microsoft/FLAML/issues/1317
+    In this test we take the best regression model which FLAML provided us, and then retrain and test it on the
+    same folds, to verify that the result is reproducible.
+    """
+    automl = AutoML()
+    automl_settings = {
+        "max_iter": 2,
+        "time_budget": -1,
+        "task": "regression",
+        "n_jobs": 1,
+        "estimator_list": [estimator],
+        "eval_method": "cv",
+        "n_splits": 3,
+        "metric": "r2",
+        "keep_search_state": True,
+    }
+    X, y = fetch_california_housing(return_X_y=True)
+    automl.fit(X_train=X, y_train=y, **automl_settings)
+    best_model = automl.model
+    assert best_model is not None
+    config = best_model.get_params()
+    val_loss_flaml = automl.best_result["val_loss"]
+
+    # Take the best model, and see if we can reproduce the best result
+    reproduced_val_loss, metric_for_logging, train_time, pred_time = automl._state.task.evaluate_model_CV(
+        config=config,
+        estimator=best_model,
+        X_train_all=automl._state.X_train_all,
+        y_train_all=automl._state.y_train_all,
+        budget=None,
+        kf=automl._state.kf,
+        eval_metric="r2",
+        best_val_loss=None,
+        cv_score_agg_func=None,
+        log_training_metric=False,
+        fit_kwargs=None,
+        free_mem_ratio=0,
+    )
+    assert pytest.approx(val_loss_flaml) == reproduced_val_loss
 
 
 if __name__ == "__main__":

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -1,4 +1,5 @@
 import unittest
+from test.conftest import evaluate_cv_folds_with_underlying_model
 
 import numpy as np
 import pytest
@@ -11,7 +12,6 @@ from sklearn.datasets import (
 from flaml import AutoML
 from flaml.automl.data import get_output_from_log
 from flaml.automl.model import XGBoostEstimator
-from test.conftest import evaluate_cv_folds_with_underlying_model
 
 
 def logregobj(preds, dtrain):
@@ -264,7 +264,7 @@ def test_reproducibility_of_regression_models(estimator: str):
         "n_splits": 3,
         "metric": "r2",
         "keep_search_state": True,
-        "skip_transform":True
+        "skip_transform": True,
     }
     X, y = fetch_california_housing(return_X_y=True, as_frame=True)
     automl.fit(X_train=X, y_train=y, **automl_settings)
@@ -290,6 +290,7 @@ def test_reproducibility_of_regression_models(estimator: str):
     )
     assert pytest.approx(val_loss_flaml) == reproduced_val_loss
 
+
 @pytest.mark.parametrize(
     "estimator",
     [
@@ -303,18 +304,16 @@ def test_reproducibility_of_regression_models(estimator: str):
         "xgb_limitdepth",
     ],
 )
-def test_reproducibility_of_underlying_regression_models(
-    estimator: str
-):
+def test_reproducibility_of_underlying_regression_models(estimator: str):
     """FLAML finds the best model for a given dataset, which it then provides to users.
 
     However, there are reported issues where FLAML was providing an incorrect model - see here:
     https://github.com/microsoft/FLAML/issues/1317
     FLAML defines FLAMLised models, which wrap around the underlying (SKLearn/XGBoost/CatBoost) model.
     Ideally, FLAMLised models should perform identically to the underlying model, when fitted
-    to the same data, with no budget. This verifies that this is the case for regression models. 
+    to the same data, with no budget. This verifies that this is the case for regression models.
     In this test we take the best model which FLAML provided us, extract the underlying model,
-     before retraining and testing it on the same folds - to verify that the result is reproducible. 
+     before retraining and testing it on the same folds - to verify that the result is reproducible.
     """
     automl = AutoML()
     automl_settings = {
@@ -326,20 +325,21 @@ def test_reproducibility_of_underlying_regression_models(
         "eval_method": "cv",
         "n_splits": 10,
         "metric": "r2",
-        "keep_search_state":True,
-        "skip_transform":True
+        "keep_search_state": True,
+        "skip_transform": True,
     }
     X, y = fetch_california_housing(return_X_y=True, as_frame=True)
     automl.fit(X_train=X, y_train=y, **automl_settings)
     best_model = automl.model
     assert best_model is not None
     val_loss_flaml = automl.best_result["val_loss"]
-    reproduced_val_loss_underlying_model = np.mean(evaluate_cv_folds_with_underlying_model(automl._state.X_train_all, 
-                                                        automl._state.y_train_all, automl._state.kf,
-                                                                                     best_model.model, 'regression'))
-    
-    assert pytest.approx(val_loss_flaml)  == reproduced_val_loss_underlying_model
+    reproduced_val_loss_underlying_model = np.mean(
+        evaluate_cv_folds_with_underlying_model(
+            automl._state.X_train_all, automl._state.y_train_all, automl._state.kf, best_model.model, "regression"
+        )
+    )
 
+    assert pytest.approx(val_loss_flaml) == reproduced_val_loss_underlying_model
 
 
 if __name__ == "__main__":

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,13 +1,12 @@
 from typing import Any, Dict, List, Union
-from catboost import CatBoostClassifier, CatBoostRegressor, Pool
-from sklearn.metrics import f1_score
-from sklearn.metrics import r2_score
+
 import numpy as np
 import pandas as pd
+from catboost import CatBoostClassifier, CatBoostRegressor, Pool
+from sklearn.metrics import f1_score, r2_score
 
-def evaluate_cv_folds_with_underlying_model(
-        X_train_all, y_train_all, kf,model: Any, task: str
-) -> pd.DataFrame:
+
+def evaluate_cv_folds_with_underlying_model(X_train_all, y_train_all, kf, model: Any, task: str) -> pd.DataFrame:
     """Mimic the FLAML CV process to calculate the metrics across each fold.
 
     :param X_train_all: X training data
@@ -32,12 +31,10 @@ def evaluate_cv_folds_with_underlying_model(
             use_best_model = True
             n = max(int(len(y_train) * 0.9), len(y_train) - 1000) if use_best_model else len(y_train)
             X_tr, y_tr = (X_train)[:n], y_train[:n]
-            eval_set = (
-                Pool(data=X_train[n:], label=y_train[n:], cat_features=[]) if use_best_model else None
-            )
+            eval_set = Pool(data=X_train[n:], label=y_train[n:], cat_features=[]) if use_best_model else None
             model.fit(X_tr, y_tr, eval_set=eval_set, use_best_model=True)
         y_pred_classes = model.predict(X_val)
-        if task == 'classification':
+        if task == "classification":
             reproduced_metric = 1 - f1_score(y_val, y_pred_classes)
         else:
             reproduced_metric = 1 - r2_score(y_val, y_pred_classes)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,45 @@
+from typing import Any, Dict, List, Union
+from catboost import CatBoostClassifier, CatBoostRegressor, Pool
+from sklearn.metrics import f1_score
+from sklearn.metrics import r2_score
+import numpy as np
+import pandas as pd
+
+def evaluate_cv_folds_with_underlying_model(
+        X_train_all, y_train_all, kf,model: Any, task: str
+) -> pd.DataFrame:
+    """Mimic the FLAML CV process to calculate the metrics across each fold.
+
+    :param X_train_all: X training data
+    :param y_train_all: y training data
+    :param kf: The splitter object to use to generate the folds
+    :param model: The estimator to fit to the data during the CV process
+    :param task: classification or regression
+    :return: An array containing the metrics
+    """
+    rng = np.random.RandomState(2020)
+    all_fold_metrics: List[Dict[str, Union[int, float]]] = []
+    for train_index, val_index in kf.split(X_train_all, y_train_all):
+        X_train_split, y_train_split = X_train_all, y_train_all
+        train_index = rng.permutation(train_index)
+        X_train = X_train_split.iloc[train_index]
+        X_val = X_train_split.iloc[val_index]
+        y_train, y_val = y_train_split[train_index], y_train_split[val_index]
+        model_type = type(model)
+        if model_type is not CatBoostClassifier and model_type is not CatBoostRegressor:
+            model.fit(X_train, y_train)
+        else:
+            use_best_model = True
+            n = max(int(len(y_train) * 0.9), len(y_train) - 1000) if use_best_model else len(y_train)
+            X_tr, y_tr = (X_train)[:n], y_train[:n]
+            eval_set = (
+                Pool(data=X_train[n:], label=y_train[n:], cat_features=[]) if use_best_model else None
+            )
+            model.fit(X_tr, y_tr, eval_set=eval_set, use_best_model=True)
+        y_pred_classes = model.predict(X_val)
+        if task == 'classification':
+            reproduced_metric = 1 - f1_score(y_val, y_pred_classes)
+        else:
+            reproduced_metric = 1 - r2_score(y_val, y_pred_classes)
+        all_fold_metrics.append(reproduced_metric)
+    return all_fold_metrics


### PR DESCRIPTION
## Why are these changes needed?

See associated issue #1361. There's a few issues around model reproducibility, and these tests will help identify where those issues are. I have commented out models which fail in the new tests, and these show where the reproducibility issues lie - largely around CatBoost, LGBM and Logistic Regression models.

I have added four separate tests in total, all of which aim to verify that we can reproduce the validation loss FLAML gives us, using the model which FLAML provides us with. The 4 tests deal with the following cases:
1. Reproduce the FLAML result, for the classification case, using the FLAMLised model.
2. Reproduce the FLAML result, for the classification case, using the underlying SKLearn/xgboost/catboost model.
3. Reproduce the FLAML result, for the regression case, using the FLAMLised model.
4. Reproduce the FLAML result, for the regression case, using the underlying SKLearn/xgboost/catboost model.

Tests 1 and 3, which deal with the FLAMLised model, are fairly self-explanatory (I hope). For the other tests (2 and 4) I had to define my own method on `conftest.py`, `evaluate_cv_folds_with_underlying_model`, which aims to mimic the FLAML cross-validation process. I couldn't directly call on `generic_task.evaluate_model_CV()` here, as that method doesn't work with non-FLAMLised estimators. The line `estimator.cleanup()` raises an error, for example.

Thanks for any feedback -please let me know of any changes which might be needed

## Related issue number

Closes #1361 


## Checks

- [X] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [X] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
