### PR TITLE
fix: FLAML catboost metrics arent reproducible

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2090,6 +2090,8 @@ class CatBoostEstimator(BaseEstimator):
         if weight is not None:
             kwargs["sample_weight"] = weight
         self._model = model
+        # Commented-out line below incorrectly assigned n_estimators - see https://github.com/microsoft/FLAML/pull/1364
+        # self.params[self.ITER_HP] = self._model.tree_count_
         train_time = time.time() - start_time
         return train_time
 

--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2753,7 +2753,7 @@ class BaseResourceLimit:
     def check_resource_limits(self, current_time, current_iteration, mllib):
         if (mllib == "xgb" and current_iteration == 0) or (mllib == "cat" and current_iteration == 1):
             self._time_per_iter = current_time - self.start_time
-        if current_time + self._time_per_iter > self.deadline:
+        if mllib != "cat" and current_time + self._time_per_iter > self.deadline:
             return False
         if psutil is not None and self.free_mem_ratio is not None:
             mem = psutil.virtual_memory()

--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2090,7 +2090,6 @@ class CatBoostEstimator(BaseEstimator):
         if weight is not None:
             kwargs["sample_weight"] = weight
         self._model = model
-        self.params[self.ITER_HP] = self._model.tree_count_
         train_time = time.time() - start_time
         return train_time
 
@@ -2752,8 +2751,6 @@ class BaseResourceLimit:
     def check_resource_limits(self, current_time, current_iteration, mllib):
         if (mllib == "xgb" and current_iteration == 0) or (mllib == "cat" and current_iteration == 1):
             self._time_per_iter = current_time - self.start_time
-        if current_time + self._time_per_iter > self.deadline:
-            return False
         if psutil is not None and self.free_mem_ratio is not None:
             mem = psutil.virtual_memory()
             if mem.available / mem.total < self.free_mem_ratio:

--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2753,6 +2753,8 @@ class BaseResourceLimit:
     def check_resource_limits(self, current_time, current_iteration, mllib):
         if (mllib == "xgb" and current_iteration == 0) or (mllib == "cat" and current_iteration == 1):
             self._time_per_iter = current_time - self.start_time
+        if current_time + self._time_per_iter > self.deadline:
+            return False
         if psutil is not None and self.free_mem_ratio is not None:
             mem = psutil.virtual_memory()
             if mem.available / mem.total < self.free_mem_ratio:

--- a/test/automl/test_classification.py
+++ b/test/automl/test_classification.py
@@ -427,7 +427,7 @@ class TestClassification(unittest.TestCase):
 @pytest.mark.parametrize(
     "estimator",
     [
-        # "catboost",
+        "catboost",
         "extra_tree",
         "histgb",
         "kneighbor",
@@ -488,7 +488,7 @@ def test_reproducibility_of_classification_models(estimator: str):
 @pytest.mark.parametrize(
     "estimator",
     [
-        # "catboost",
+        "catboost",
         "extra_tree",
         "histgb",
         "kneighbor",

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -294,7 +294,7 @@ def test_reproducibility_of_regression_models(estimator: str):
 @pytest.mark.parametrize(
     "estimator",
     [
-        # "catboost",
+        "catboost",
         "extra_tree",
         "histgb",
         "kneighbor",

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -235,7 +235,7 @@ def test_multioutput():
 @pytest.mark.parametrize(
     "estimator",
     [
-        # "catboost",
+        "catboost",
         "extra_tree",
         "histgb",
         "kneighbor",


### PR DESCRIPTION
Note: Please don't merge without a discussion first

## Why are these changes needed?

Currently it is impossible to reproduce the best_loss provided by FLAML, using the best model which FLAML provides - when that best model is a CatBoost model.

<!-- Please give a short summary of the change and the problem this solves. -->

There are two important changes made in this PR:

1. Removal of `self.params[self.ITER_HP] = self._model.tree_count_` line on `model.py`
2. Removal of this if statement from `model.py`: ` if current_time + self._time_per_iter > self.deadline:
            return False`

The line highlighted in 1) is the cause of issue #1317. As I understand it, CatBoost estimators can be thought of as performing their own AutoML/optimisation process internally - they have early stopping, and when `use_best_model = True` they internally optimise the objective metric. The issue with the current code is that it overwrites the n_estimators value with the actual number of trees used, but doesn't switch off this AutoML functionality. Rather than providing the user with the correct model, we simply change the internal AutoML process. As such, we get different results when we retrain and test that model on the same folds.

2) is a little trickier, and needs some discussion. Essentially the callbacks change the behaviour of the models, when the time_budget remaining is less than the time which the model will take to train. This means that when we take the model FLAML provides, and refit it on the same folds but with no time budget involved, we get different behaviour and different results. I imagine that this callback was likely implemented as a means of ensuring that FLAML respects the time budget, but I personally think that results which aren't reproducible are not particularly useful. 

My main issue with 2) is that the `XGBoostEstimator` also utilises this same `check_resource_limits()`, so this change could have unintended consequences. On a similar note, I've realised that `XGBoostEstimator` and `CatBoostEstimators` call  `check_resource_limits` differently i.e.:
```
class XGBoostResourceLimit(BaseResourceLimit, TrainingCallback):
    def after_iteration(self, model, epoch, evals_log) -> bool:
        now = time.time()
        return not self.check_resource_limits(now, epoch, "xgb")


class CatBoostResourceLimit(BaseResourceLimit):
    def after_iteration(self, info) -> bool:
        now = time.time()
        return self.check_resource_limits(now, info.iteration, "cat")
```

Could you please explain why XGBoostResourceLimit returns `return not self.check_resource_limits(now, epoch, "xgb")` whilst CatBoostResourceLimit returns `self.check_resource_limits(now, info.iteration, "cat")` please?

It's the `not` part which I'm interested in.

Also worth mentioning is that we still assign `self._time_per_iter` in `check_resource_limits`. Can this code also be deleted, or is it still of use somewhere?

I'm fairly confident now that CatBoost results are now reproducible, but please let me know if you have any issues with my code.

## Related issue number

Closes #1317 

## Checks

- [X] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [X] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
