### PR TITLE
Fix logging issues that can arise when importing flaml

### DIFF
--- a/flaml/__init__.py
+++ b/flaml/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 try:
     from flaml.automl import AutoML, logger_formatter
@@ -12,7 +13,8 @@ from flaml.version import __version__
 
 # Set the root logger.
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+if logger.level == logging.NOTSET:
+    logger.setLevel(logging.INFO)
 
 if not has_automl:
-    logger.warning("flaml.automl is not available. Please install flaml[automl] to enable AutoML functionalities.")
+    warnings.warn("flaml.automl is not available. Please install flaml[automl] to enable AutoML functionalities.")


### PR DESCRIPTION
Previously, FLAML would automatically set its own loglevel when imported, overriding any other logging settings that may previously have been set by users of the library. FLAML will now check whether a loglevel has been explicitly set before setting its own.

In addition, the `flaml.automl` warning is now emitted using `warnings` rather than `logging.warning`. This falls more in line with other FLAML submodules (e.g. `flaml.ml`).

Taken in conjunction, these two changes make it a lot easier for downstream users to suppress warnings emitted by FLAML upon importing the library, either by configuring logging prior to importing `flaml` or by using the somewhat more idiomatic
```
with warnings.catch_warnings(action="ignore"):
    import flaml
```
This change also helps to ensure that FLAML's defaults won't override users' explicit logging settings.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes make it easier for downstream users to configure FLAML's logging utilities as they see fit, and make it easier to suppress certain warnings that may occur when importing `flaml` for the first time.

## Related issue number

N/A

## Checks

- [X] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [X] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
