### PR TITLE
fix: Fixed bug with catboost and groups

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2066,8 +2066,8 @@ class CatBoostEstimator(BaseEstimator):
             self.estimator_class = CatBoostRegressor
 
     def fit(self, X_train, y_train, budget=None, free_mem_ratio=0, **kwargs):
-        if "is_retrain" in kwargs:
-            kwargs.pop("is_retrain")
+        kwargs.pop("is_retrain", None)
+        kwargs.pop("groups", None)
         start_time = time.time()
         deadline = start_time + budget if budget else np.inf
         train_dir = f"catboost_{str(start_time)}"

--- a/test/automl/test_split.py
+++ b/test/automl/test_split.py
@@ -68,7 +68,7 @@ def test_groups():
         "model_history": True,
         "eval_method": "cv",
         "groups": np.random.randint(low=0, high=10, size=len(y)),
-        "estimator_list": ["lgbm", "rf", "xgboost", "kneighbor"],
+        "estimator_list": ["catboost", "lgbm", "rf", "xgboost", "kneighbor"],
         "learner_selector": "roundrobin",
     }
     automl.fit(X, y, **automl_settings)
@@ -108,6 +108,7 @@ def test_stratified_groupkfold():
         "split_type": splitter,
         "groups": X_train["Airline"],
         "estimator_list": [
+            "catboost",
             "lgbm",
             "rf",
             "xgboost",


### PR DESCRIPTION
## Why are these changes needed?

Currently an error is raised when we attempt to use a group-based split (such as `GroupKFold` or `StratifiedGroupKFold`) with CatBoost. This issue is caused by the `fit()` method on `CatBoostEstimator`, in particular this part:

```
            model.fit(
                X_tr,
                y_tr,
                cat_features=cat_features,
                eval_set=eval_set,
                callbacks=CatBoostEstimator._callbacks(
                    start_time, deadline, free_mem_ratio if use_best_model else None
                ),
                **kwargs,
            )
```

When `groups` is not None, kwargs contains the groups. CatBoost fit methods don't accept groups, which causes the issue.

As I understand it, groups in FLAML (and generally) should be used when splitting data, _not_ when fitting data. Basically, CatBoost does not need groups to be passed in, and likely never will.

I've been through the other FLAML estimators, and they all seem to remove groups from kwargs before calling `model.fit`. For example, in the `_fit()` method on the `BaseEstimator` class defined on `flaml/automl/model.py`, we have the following code:

```
        if "groups" in kwargs:
            kwargs = kwargs.copy()
            groups = kwargs.pop("groups")
            if self._task == "rank":
                kwargs["group"] = group_counts(groups)
```

This code removes `groups` from the kwargs dictionary, before `model.fit()` is called.

I've mimicked this 'removal of groups from kwargs' in my code. I've also updated the two tests of group-related splits to include CatBoost as an estimator. Before my changes, the addition of catboost causes these tests to fail, but after removing the groups from kwargs, they pass :)

I welcome any feedback!

## Related issue number

Closes #304 
## Checks

- [X] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [X] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
