### PR TITLE
Improved error handling in case no scikit present

### DIFF
--- a/flaml/automl/contrib/histgb.py
+++ b/flaml/automl/contrib/histgb.py
@@ -1,7 +1,7 @@
 try:
     from sklearn.ensemble import HistGradientBoostingClassifier, HistGradientBoostingRegressor
-except ImportError:
-    pass
+except ImportError as e:
+    raise ImportError("scikit-learn is required for HistGradientBoostingEstimator. Please install it.") from e
 
 from flaml import tune
 from flaml.automl.model import SKLearnEstimator


### PR DESCRIPTION
Currently there is no description for when this error is thrown. Being explicit seems of value.


## Why are these changes needed?

This PR improves error handling for the contrib module.

## Related issue number
https://github.com/microsoft/FLAML/issues/1401

## Checks

- [ x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [ x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ x] I've made sure all auto checks have passed.
