### PR TITLE
Fix 'list index out of range' Error with 'mlflow_logging': True and 'max_iter': 1

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -2521,8 +2521,8 @@ class AutoML(BaseEstimator):
         self._warn_threshold = 10
         self._selected = None
         self.modelcount = 0
-        if self._max_iter < 2 and self.estimator_list and self._state.retrain_final:
-            # when max_iter is 1, no need to search
+        if self._max_iter < 1 and self.estimator_list and self._state.retrain_final:
+            # when max_iter is 1, search is also necessary for test. Besides, it won't take a lot of time.
             self.modelcount = self._max_iter
             self._max_iter = 0
             self._best_estimator = estimator = self.estimator_list[0]

--- a/flaml/fabric/mlflow.py
+++ b/flaml/fabric/mlflow.py
@@ -504,13 +504,16 @@ class MLflowIntegration:
             self.adopt_children(automl)
 
         if self.manual_log:
-            best_mlflow_run_id = self.manual_run_ids[automl._best_iteration]
+            if len(self.manual_run_ids) == 0:
+                best_mlflow_run_id = self.parent_run_id or mlflow.active_run().info.run_id
+            else:
+                best_mlflow_run_id = self.manual_run_ids[automl._best_iteration]
             best_run_name = self.mlflow_client.get_run(best_mlflow_run_id).info.run_name
             automl.best_run_id = best_mlflow_run_id
             automl.best_run_name = best_run_name
             self.mlflow_client.set_tag(best_mlflow_run_id, "flaml.best_run", True)
             self.best_run_id = best_mlflow_run_id
-            if self.parent_run_id is not None:
+            if self.parent_run_id is not None or (automl._config_history and automl._best_iteration in automl._config_history):
                 conf = automl._config_history[automl._best_iteration][1].copy()
                 if "ml" in conf.keys():
                     conf = conf["ml"]

--- a/flaml/fabric/mlflow.py
+++ b/flaml/fabric/mlflow.py
@@ -513,10 +513,13 @@ class MLflowIntegration:
             automl.best_run_name = best_run_name
             self.mlflow_client.set_tag(best_mlflow_run_id, "flaml.best_run", True)
             self.best_run_id = best_mlflow_run_id
-            if self.parent_run_id is not None or (automl._config_history and automl._best_iteration in automl._config_history):
-                conf = automl._config_history[automl._best_iteration][1].copy()
-                if "ml" in conf.keys():
-                    conf = conf["ml"]
+            if self.parent_run_id is not None:
+                conf = {}
+                if automl._best_iteration in automl._config_history:###
+                    conf = automl._config_history[automl._best_iteration][1].copy()
+                    if "ml" in conf.keys():
+                        conf = conf["ml"]
+
 
                 mlflow.log_params(conf)
                 mlflow.log_param("best_learner", automl._best_estimator)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR handles empty manual_run_ids to prevent 'list index out of range' error. 
The fix ensures that if manual_run_ids is empty, best_mlflow_run_id falls back to self.parent_run_id or the active MLflow run ID before attempting to access manual_run_ids.

## Related issue number

 closes #1416 

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
