### PR TITLE
Fix issue with "list index out of range" when max_iter=1

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -2529,6 +2529,26 @@ class AutoML(BaseEstimator):
             self._selected = state = self._search_states[estimator]
             state.best_config_sample_size = self._state.data_size[0]
             state.best_config = state.init_config[0] if state.init_config else {}
+            self._track_iter = 0
+            self._config_history[self._track_iter] = (
+                estimator,
+                state.best_config,
+                self._state.time_from_start
+            )
+            self._best_iteration = self._track_iter
+            state.val_loss = getattr(state, 'val_loss', float('inf'))
+            state.best_loss = getattr(state, 'best_loss', float('inf'))
+            state.config = getattr(state, 'config', state.best_config.copy())
+            state.metric_for_logging = getattr(state, 'metric_for_logging', None)
+            state.sample_size = getattr(state, 'sample_size', self._state.data_size[0])
+            state.learner_class = getattr(state, 'learner_class', 
+                self._state.learner_classes.get(estimator))
+            if hasattr(self, 'mlflow_integration') and self.mlflow_integration:
+                self.mlflow_integration.record_state(
+                    automl=self,
+                    search_state=state,
+                    estimator=estimator,
+                ) 
         elif self._use_ray is False and self._use_spark is False:
             self._search_sequential()
         else:

--- a/test/automl/test_max_iter_1.py
+++ b/test/automl/test_max_iter_1.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import numpy as np
+from flaml import AutoML
+import mlflow
+
+def test_max_iter_1():
+    date_rng = pd.date_range(start='2024-01-01', periods=100, freq='H')
+    X = pd.DataFrame({'ds': date_rng})
+    y_train_24h = np.random.rand(len(X)) * 100
+
+    # AutoML
+    settings = {
+        "max_iter": 1,
+        "estimator_list": ['xgboost', 'lgbm'],
+        "starting_points": {'xgboost': {}, 'lgbm': {}},
+        "task": "ts_forecast",
+        "log_file_name": "test_max_iter_1.log",
+        "seed": 41,
+        "mlflow_exp_name": "TestExp-max_iter-1",
+        "use_spark": False,
+        "n_concurrent_trials": 1,
+        "verbose": 1,
+        "featurization": "off",
+        "metric": "rmse",
+        "mlflow_logging": True,
+    }
+
+    automl = AutoML(**settings)
+
+    with mlflow.start_run(run_name="AutoMLModel-XGBoost-and-LGBM-max_iter_1") as run:
+        automl.fit(
+            X_train=X,
+            y_train=y_train_24h,
+            period=24,
+            X_val=X,
+            y_val=y_train_24h,
+            split_ratio=0,
+            force_cancel=False,
+        )
+
+    assert automl.model is not None, "AutoML failed to return a model"
+    assert automl.best_run_id is not None, "Best run ID should not be None with mlflow logging"
+
+    print("Best model:", automl.model)
+    print("Best run ID:", automl.best_run_id)
+
+if __name__ == "__main__":
+    test_max_iter_1()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes a bug where `record_state` was not called when `max_iter=1`, ensuring consistent behavior across all iteration counts.
The file 'test_max_iter_1.py' are needed to test that the AutoML process runs correctly by setting `max_iter=1`, allowing model training and hyperparameter optimization.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#1416 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
