### PR TITLE
Revert "Numpy 2.x is not supported yet."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(here, "flaml/version.py")) as fp:
 __version__ = version["__version__"]
 
 install_requires = [
-    "NumPy>=1.17,<2",
+    "NumPy>=1.17",
 ]
 
 


### PR DESCRIPTION
Reverts microsoft/FLAML#1424. Numpy 2.x is actually supported in the latest release.

Close #1423 