### PR TITLE
fix:When use_spark = True and mlflow_logging = True are set, an error is reported when logging the best model: 'NoneType' object has no attribute 'save' bug Something isn't working

### DIFF
--- a/flaml/fabric/mlflow.py
+++ b/flaml/fabric/mlflow.py
@@ -495,7 +495,7 @@ class MLflowIntegration:
                 if (
                     automl._trained_estimator is not None
                     and not self.has_model
-                    and self._trained_estimator._model is not None
+                    and automl._trained_estimator._model is not None
                 ):
                     self.log_model(
                         automl._trained_estimator._model, automl.best_estimator, signature=automl.estimator_signature
@@ -528,7 +528,7 @@ class MLflowIntegration:
                     if (
                         automl._trained_estimator is not None
                         and not self.has_model
-                        and self._trained_estimator._model is not None
+                        and automl._trained_estimator._model is not None
                     ):
                         self.log_model(
                             automl._trained_estimator._model,

--- a/flaml/fabric/mlflow.py
+++ b/flaml/fabric/mlflow.py
@@ -492,7 +492,11 @@ class MLflowIntegration:
                 mlflow.log_metric("best_validation_loss", automl._state.best_loss)
                 mlflow.log_metric("best_iteration", automl._best_iteration)
                 mlflow.log_metric("num_child_runs", len(self.infos))
-                if automl._trained_estimator is not None and not self.has_model:
+                if (
+                    automl._trained_estimator is not None
+                    and not self.has_model
+                    and self._trained_estimator._model is not None
+                ):
                     self.log_model(
                         automl._trained_estimator._model, automl.best_estimator, signature=automl.estimator_signature
                     )
@@ -521,7 +525,11 @@ class MLflowIntegration:
                     logger.info(f"logging best model {automl.best_estimator}")
                     self.copy_mlflow_run(best_mlflow_run_id, self.parent_run_id)
                     self.has_summary = True
-                    if automl._trained_estimator is not None and not self.has_model:
+                    if (
+                        automl._trained_estimator is not None
+                        and not self.has_model
+                        and self._trained_estimator._model is not None
+                    ):
                         self.log_model(
                             automl._trained_estimator._model,
                             automl.best_estimator,

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
             "psutil==5.8.0",
             "dataclasses",
             "transformers[torch]==4.26",
-            "datasets",
+            "datasets<=3.5.0",
             "nltk<=3.8.1",  # 3.8.2 doesn't work with mlflow
             "rouge_score",
             "hcrystalball==0.1.10",


### PR DESCRIPTION
fix:When use_spark = True and mlflow_logging = True are set, an error is reported when logging the best model: 'NoneType' object has no attribute 'save' bug Something isn't working)

<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When use_spark = True and mlflow_logging = True are set, an error is reported when logging the best model: 'NoneType' object has no attribute 'save' bug Something isn't working
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#1431 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
