### PR TITLE
feat: improve infer_lang() robustness with shebang and shell pattern detection

### DIFF
--- a/flaml/autogen/code_utils.py
+++ b/flaml/autogen/code_utils.py
@@ -27,11 +27,64 @@ DEFAULT_TIMEOUT = 600
 
 
 def infer_lang(code):
-    """infer the language for the code.
-    TODO: make it robust.
+    """Infer the language for the code based on syntax patterns.
+
+    Args:
+        code (str): The code string to analyze.
+
+    Returns:
+        str: The inferred language, either "python" or "sh".
     """
-    if code.startswith("python ") or code.startswith("pip") or code.startswith("python3 "):
-        return "sh"
+    if not code:
+        return "python"
+
+    code = code.strip()
+
+    # Check for shebang line
+    if code.startswith("#!"):
+        first_line = code.split("\n")[0].lower()
+        if "python" in first_line:
+            return "python"
+        if "bash" in first_line or "/sh" in first_line:
+            return "sh"
+
+    # Shell command patterns - commands that indicate shell execution
+    shell_patterns = (
+        "python ",
+        "python3 ",
+        "pip ",
+        "pip3 ",
+        "cd ",
+        "ls ",
+        "mkdir ",
+        "rm ",
+        "cp ",
+        "mv ",
+        "chmod ",
+        "chown ",
+        "sudo ",
+        "apt ",
+        "apt-get ",
+        "brew ",
+        "npm ",
+        "yarn ",
+        "curl ",
+        "wget ",
+        "echo ",
+        "export ",
+        "source ",
+        "cat ",
+        "grep ",
+        "find ",
+        "tar ",
+        "unzip ",
+        "git ",
+    )
+    for pattern in shell_patterns:
+        if code.startswith(pattern):
+            return "sh"
+
+    # Default to python
     return "python"
 
 
@@ -280,9 +333,7 @@ def execute_code(
     image_list = (
         ["python:3-alpine", "python:3", "python:3-windowsservercore"]
         if use_docker is True
-        else [use_docker]
-        if isinstance(use_docker, str)
-        else use_docker
+        else [use_docker] if isinstance(use_docker, str) else use_docker
     )
     for image in image_list:
         # check if the image exists

--- a/test/autogen/test_code.py
+++ b/test/autogen/test_code.py
@@ -152,6 +152,19 @@ here = os.path.abspath(os.path.dirname(__file__))
 def test_infer_lang():
     assert infer_lang("print('hello world')") == "python"
     assert infer_lang("pip install flaml") == "sh"
+    assert infer_lang("pip3 install flaml") == "sh"
+    assert infer_lang("cd .") == "sh"
+    assert infer_lang("ls -l") == "sh"
+    assert infer_lang("#!/bin/bash\necho hello") == "sh"
+    assert infer_lang("#!/usr/bin/python\nprint('hello')") == "python"
+    assert infer_lang("") == "python"
+    assert infer_lang("  python script.py") == "sh"
+    assert infer_lang("apt-get install -y python3") == "sh"
+    assert infer_lang("curl https://example.com") == "sh"
+    assert infer_lang("grep -r 'hello' .") == "sh"
+    assert infer_lang("git status") == "sh"
+    assert infer_lang("npm install") == "sh"
+
 
 
 def test_extract_code():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR addresses a TODO in `flaml/autogen/code_utils.py` to make the `infer_lang()` function more robust.

The previous implementation relied on a simple heuristic that only detected shell code if it started strictly with "python ", "pip", or "python3 ". This misses many common shell scenarios and valid Python scripts.

**Improvements included in this PR:**

1.  **Shebang Detection**: Added support for checking shebang lines (e.g., `#!/bin/bash`, `#!/usr/bin/python`) to accurately identify the language.
2.  **Expanded Shell Patterns**: Significantly expanded the list of shell command patterns to include common commands like `cd`, `ls`, `mkdir`, `git`, `npm`, `curl`, etc.
3.  **Robustness**: Added handling for empty input and whitespace stripping before pattern matching.
4.  **Documentation**: Added a proper docstring with Args and Returns.

## Related issue number
closes #1489 
## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
