### PR TITLE
ci: skip pre-commit workflow on main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,8 +3,6 @@ name: Code formatting
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   pull_request: {}
-  push:
-    branches-ignore: [main]
 
 defaults:
   run:


### PR DESCRIPTION
## Summary
- Skip the pre-commit GitHub Actions workflow on pushes to `main`.
- Keep pre-commit checks running on all pull requests.

## Why
PR checks already gate merges; avoiding errors on `main`.