### PR TITLE
fix: SGD results now reproducible

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2450,8 +2450,9 @@ class SGDEstimator(SKLearnEstimator):
 
     def __init__(self, task="binary", **config):
         super().__init__(task, **config)
+        random_seed = self.params.pop("random_seed", config.get("random_seed", 10242048))
         if "random_state" not in self.params:
-            self.params["random_state"] = config.get("random_seed", 10242048)
+            self.params["random_state"] = random_seed
         if self._task.is_classification():
             self.estimator_class = SGDClassifier
         elif self._task.is_regression():

--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2450,6 +2450,11 @@ class SGDEstimator(SKLearnEstimator):
 
     def __init__(self, task="binary", **config):
         super().__init__(task, **config)
+        self.params.update(
+            {
+                "random_state": config.get("random_seed", 10242048),
+            }
+        )
         if self._task.is_classification():
             self.estimator_class = SGDClassifier
         elif self._task.is_regression():

--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2450,11 +2450,8 @@ class SGDEstimator(SKLearnEstimator):
 
     def __init__(self, task="binary", **config):
         super().__init__(task, **config)
-        self.params.update(
-            {
-                "random_state": config.get("random_seed", 10242048),
-            }
-        )
+        if "random_state" not in self.params:
+            self.params["random_state"] = config.get("random_seed", 10242048)
         if self._task.is_classification():
             self.estimator_class = SGDClassifier
         elif self._task.is_regression():

--- a/test/automl/test_classification.py
+++ b/test/automl/test_classification.py
@@ -435,6 +435,7 @@ class TestClassification(unittest.TestCase):
         # "lrl1",
         "lrl2",
         "rf",
+        "sgd",
         "svc",
         "xgboost",
         "xgb_limitdepth",
@@ -498,6 +499,9 @@ def test_reproducibility_of_classification_models(estimator: str):
         "lrl2",
         "svc",
         "rf",
+        # "sgd" omitted: SGDEstimator wraps the sklearn model with a Normalizer
+        # preprocessing step that this test's helper does not replicate, so the
+        # bare underlying model cannot match the FLAML wrapper's CV result.
         "xgboost",
         "xgb_limitdepth",
     ],

--- a/test/automl/test_classification.py
+++ b/test/automl/test_classification.py
@@ -499,9 +499,6 @@ def test_reproducibility_of_classification_models(estimator: str):
         "lrl2",
         "svc",
         "rf",
-        # "sgd" omitted: SGDEstimator wraps the sklearn model with a Normalizer
-        # preprocessing step that this test's helper does not replicate, so the
-        # bare underlying model cannot match the FLAML wrapper's CV result.
         "xgboost",
         "xgb_limitdepth",
     ],

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -408,9 +408,6 @@ def test_reproducibility_of_lgbm_regression_model():
         "kneighbor",
         "lgbm",
         "rf",
-        # "sgd" omitted: SGDEstimator wraps the sklearn model with a Normalizer
-        # preprocessing step that this test's helper does not replicate, so the
-        # bare underlying model cannot match the FLAML wrapper's CV result.
         "xgboost",
         "xgb_limitdepth",
     ],

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -254,6 +254,7 @@ def test_multioutput():
         "kneighbor",
         "lgbm",
         "rf",
+        "sgd",
         "xgboost",
         "xgb_limitdepth",
     ],
@@ -407,6 +408,9 @@ def test_reproducibility_of_lgbm_regression_model():
         "kneighbor",
         "lgbm",
         "rf",
+        # "sgd" omitted: SGDEstimator wraps the sklearn model with a Normalizer
+        # preprocessing step that this test's helper does not replicate, so the
+        # bare underlying model cannot match the FLAML wrapper's CV result.
         "xgboost",
         "xgb_limitdepth",
     ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/FLAML/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

## Summary
- Seed `random_state` on `SGDEstimator` so `SGDClassifier` / `SGDRegressor` produce deterministic results (uses `config.get("random_seed", 10242048)`, matching the LinearSVC and ElasticNet fixes).
- Add `"sgd"` to `test_reproducibility_of_classification_models` and `test_reproducibility_of_regression_models`.
- Intentionally do **not** add `"sgd"` to the `*_underlying_*` variants: `SGDEstimator` wraps the sklearn model with a `Normalizer` preprocessing step that the test helper does not replicate, so a bare-sklearn refit cannot match the wrapper's CV result. A short comment in each list documents this.


## Related issue number

Follows: #1369 (LGBM), #1374 (ElasticNet), #1376 (LinearSVC), #1364 (CatBoost).

## Test plan
- [x] `pytest test/automl/test_classification.py -k "reproducibility and sgd"` — passes
- [x] `pytest test/automl/test_regression.py -k "reproducibility and sgd"` — passes
## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
