### PR TITLE
ci(docs): always trigger docs workflow on PRs; move filtering into workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,7 +10,7 @@ on:
     types: [checks_requested]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
 
 jobs:
@@ -70,8 +70,6 @@ jobs:
     needs: changes
     if: github.event_name != 'pull_request' && (needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     defaults:
       run:
         working-directory: website

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,16 +3,8 @@ name: docs
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'flaml/*'
-      - 'website/*'
-      - '.github/workflows/deploy-website.yml'
   push:
     branches: [main]
-    paths:
-      - 'flaml/*'
-      - 'website/*'
-      - '.github/workflows/deploy-website.yml'
   workflow_dispatch:
   merge_group:
     types: [checks_requested]
@@ -21,8 +13,24 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'flaml/**'
+              - 'website/**'
+              - '.github/workflows/deploy-website.yml'
+
   checks:
-    if: github.event_name != 'push'
+    needs: changes
+    if: github.event_name != 'push' && (needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -58,7 +66,8 @@ jobs:
           npm run build
           fi
   gh-release:
-    if: github.event_name != 'pull_request'
+    needs: changes
+    if: github.event_name != 'pull_request' && (needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,7 +10,8 @@ on:
     types: [checks_requested]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: read
 
 jobs:
   changes:
@@ -69,6 +70,8 @@ jobs:
     needs: changes
     if: github.event_name != 'pull_request' && (needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: website


### PR DESCRIPTION
## Why

Today the `docs` workflow uses trigger-level `paths` filters. When a PR doesn't touch any of those paths, GitHub never starts the workflow, so the `docs` check is reported as *expected but not run* — which can leave required-status-check rules waiting indefinitely and makes branch-protection harder to manage.

## What

- Drop the `paths` filters from both the `pull_request` and `push` triggers so the workflow **always starts on PRs** (and on pushes to `main`) and reliably reports a check status.
- Add a `changes` job that uses [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter) to detect doc-related changes inside the workflow, with **recursive globs**:
  - `flaml/**`
  - `website/**`
  - `.github/workflows/deploy-website.yml`
- Gate the existing `checks` and `gh-release` jobs on `needs.changes.outputs.docs` so the heavy build/deploy steps are still skipped when nothing relevant changed (preserving today's compute behavior).
- `workflow_dispatch` (and `merge_group` for `checks`) can still force a run regardless of the filter.

The previous `flaml/*` / `website/*` patterns only matched files in the top of those directories — switching to `**` ensures changes anywhere in the tree are picked up.

## Behavior matrix

| Event              | `changes` | `checks`                          | `gh-release`                       |
|--------------------|-----------|-----------------------------------|------------------------------------|
| `pull_request`     | always    | runs only if doc files changed    | never                              |
| `push` to `main`   | always    | never                             | runs only if doc files changed     |
| `workflow_dispatch`| always    | always                            | always                             |
| `merge_group`      | always    | always                            | runs only if doc files changed     |