### PR TITLE
fix: RandomForestEstimator honors random_seed config

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -1970,8 +1970,6 @@ class RandomForestEstimator(SKLearnEstimator, LGBMEstimator):
             params["max_leaf_nodes"] = params.get("max_leaf_nodes", params.pop("max_leaves"))
         if not self._task.is_classification() and "criterion" in params:
             params.pop("criterion")
-        if "random_state" not in params:
-            params["random_state"] = 12032022
         return params
 
     def __init__(
@@ -1981,6 +1979,9 @@ class RandomForestEstimator(SKLearnEstimator, LGBMEstimator):
     ):
         super().__init__(task, **params)
         self.params["verbose"] = 0
+        random_seed = self.params.pop("random_seed", params.get("random_seed", 12032022))
+        if "random_state" not in self.params:
+            self.params["random_state"] = random_seed
 
         if self._task.is_classification():
             self.estimator_class = RandomForestClassifier


### PR DESCRIPTION
## Why are these changes needed?

Migrate `RandomForestEstimator` from a hardcoded `random_state=12032022` in `config2params` to the `random_seed`-aware pattern used by the recently fixed estimators (#1364, #1374, #1376, #1541, #1546).

Before this change, callers passing `AutoML(random_seed=N).fit(...)` would get the same internal `RandomForest`/`ExtraTrees` `random_state` (always `12032022`) regardless of `N` , inconsistent with how `CatBoostEstimator`, `ElasticNetEstimator`, `SVCEstimator`, `SGDEstimator`, and `LRL1Classifier` already behave. This brings `RandomForestEstimator` and the inheriting `ExtraTreesEstimator` in line with the rest of the audited estimator family.

The default value is preserved (`12032022`), so the existing reproducibility tests for `rf` and `extra_tree` in `test/automl/test_classification.py` and `test/automl/test_regression.py` continue to pass unchanged.

## Related issue number

Tracking issue: #1540
Pattern reference: #1541 (SGD), #1546 (LRL1)

## Test plan
- [x] `pytest test/automl/test_classification.py test/automl/test_regression.py -k "reproducibility and (rf or extra_tree)"` — 8/8 pass
- [x] `pre-commit run --files flaml/automl/model.py` — all hooks pass
- [x] CI green on the PR
## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
