### PR TITLE
Add explicit least-privilege permissions to CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     strategy:


### PR DESCRIPTION
## What

Adds a workflow-level `permissions: contents: read` block to `.github/workflows/CD.yml`.

## Why

`CD.yml` runs on `release: published` and:
- checks out the repository
- installs the package
- builds wheel + sdist via `setuptools`
- uploads to PyPI via `twine` using `PYPI_USERNAME` / `PYPI_PASSWORD` secrets

It does not push commits, create GitHub releases, or call the GitHub API for any write. The PyPI upload uses PyPI credentials, not `GITHUB_TOKEN`. The token only needs read access for the checkout step.

Declaring `contents: read` at the workflow level documents the minimum scope needed and removes reliance on the repository default token permissions, which is recommended by GitHub for [defense in depth](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Sibling FLAML workflows (`pre-commit.yml`, `python-package.yml`, `openai.yml`, `deploy-website.yml`) already declare permissions; this brings `CD.yml` in line with that pattern.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/CD.yml'))"` passes.
- No change to job steps or matrix; only the workflow-level `permissions:` block is added.

## Reference

[GitHub docs — Modifying the permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).