### PR TITLE
fix: XGBoostSklearnEstimator honors random_seed config

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -1874,6 +1874,9 @@ class XGBoostSklearnEstimator(SKLearnEstimator, LGBMEstimator):
         super().__init__(task, **config)
         del self.params["verbose"]
         self.params["verbosity"] = 0
+        random_seed = self.params.pop("random_seed", config.get("random_seed", 10242048))
+        if "random_state" not in self.params:
+            self.params["random_state"] = random_seed
         import xgboost as xgb
 
         if "rank" == task:


### PR DESCRIPTION
## Why are these changes needed?

Seed `random_state` on `XGBoostSklearnEstimator.__init__` so `xgb.XGBClassifier` / `xgb.XGBRegressor` / `xgb.XGBRanker` produce deterministic results across runs and honor the FLAML-internal `random_seed` config. Uses the same defensive pattern as #1541 and #1546 , pop the `random_seed` key from `self.params`, and only set `random_state` when the caller has not already provided one.

`XGBoostLimitDepthEstimator` inherits from `XGBoostSklearnEstimator`, so this PR closes two of the remaining XGBoost items in tracking issue #1540 (the non-sklearn `XGBoostEstimator` path will be addressed in a follow up PR).

Before this change, the existing `xgboost` / `xgb_limitdepth` reproducibility tests passed only because the search space init values (`subsample=1.0`, `colsample_bytree=1.0`, `colsample_bylevel=1.0`) are themselves deterministic. A different dataset or `max_iter` that explored stochastic-subsample configs would not have been reproducible.

## Related issue number

Tracking issue: #1540
Pattern reference: #1547 (RandomForest), #1541 (SGD), #1546 (LRL1)

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
