### PR TITLE
fix: XGBoostEstimator honors random_seed config

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -1779,6 +1779,9 @@ class XGBoostEstimator(SKLearnEstimator):
     ):
         super().__init__(task, **config)
         self.params["verbosity"] = 0
+        random_seed = self.params.pop("random_seed", config.get("random_seed", 10242048))
+        if "random_state" not in self.params:
+            self.params["random_state"] = random_seed
 
     def fit(self, X_train, y_train, budget=None, free_mem_ratio=0, **kwargs):
         import xgboost as xgb


### PR DESCRIPTION
## Why are these changes needed?

Seed `random_state` on `XGBoostEstimator.__init__` so its native-API `xgb.train(self.params, ...)` path produces deterministic results across runs and honors the FLAML-internal `random_seed` config. Uses the same defensive pattern shipped in #1541, #1546, #1547, and #1549 — pop the `random_seed` key from `self.params`, and only set `random_state` when the caller has not already provided one.

`XGBoostEstimator` is the non-sklearn-API XGBoost class — not bound to a user-facing string in `generic_task.py`, but reachable via:
- Direct instantiation (e.g. `flaml/automl/automl.py` uses it internally for the best-config retrain path)
- User subclassing (FLAML's own `test_regression.py` defines `MyXGB1` / `MyXGB2` subclasses that exercise this exact pattern)

This is the last XGBoost item on tracking issue #1540; the sklearn-API variants `XGBoostSklearnEstimator` and `XGBoostLimitDepthEstimator` were closed by #1549.

## Related issue number

Tracking issue: #1540
Pattern reference: #1549 (XGBoostSklearnEstimator), #1547 (RandomForest), #1541 (SGD), #1546 (LRL1)

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.