### PR TITLE
fix: prepare_data crashes with non shuffle split + sample_weight (#887, #1553)

### DIFF
--- a/flaml/automl/task/generic_task.py
+++ b/flaml/automl/task/generic_task.py
@@ -880,6 +880,7 @@ class GenericTask(Task):
                         y_train_all = np.concatenate([y_train_all, y_train_all[:n][rare_index]])
                     count += rare_count
                 logger.info(f"class {label} augmented from {rare_count} to {count}")
+        state.sample_weight_all = sample_weight_full
         SHUFFLE_SPLIT_TYPES = ["uniform", "stratified"]
         if is_spark_dataframe:
             # no need to shuffle pyspark dataframe
@@ -952,7 +953,7 @@ class GenericTask(Task):
                     ) = self._split_pyspark(state, X_train_all, y_train_all, split_ratio)
                 else:
                     X_train, X_val, y_train, y_val = self._split_pyspark(state, X_train_all, y_train_all, split_ratio)
-            if split_type == "group":
+            elif split_type == "group":
                 gss = GroupShuffleSplit(n_splits=1, test_size=split_ratio, random_state=RANDOM_SEED)
                 for train_idx, val_idx in gss.split(X_train_all, y_train_all, state.groups_all):
                     if data_is_df:

--- a/test/automl/test_split.py
+++ b/test/automl/test_split.py
@@ -52,6 +52,28 @@ def test_time():
     _test(split_type="time")
 
 
+def test_time_split_with_sample_weight():
+    """Regression for #887 and #1553: split_type='time' + sample_weight + holdout."""
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification(n_samples=200, n_features=10, n_informative=5, random_state=42)
+    sample_weight = np.ones(len(y))
+    automl = AutoML()
+    automl.fit(
+        X_train=X,
+        y_train=y,
+        sample_weight=sample_weight,
+        split_type="time",
+        retrain_full=True,
+        eval_method="holdout",
+        task="classification",
+        time_budget=-1,
+        max_iter=2,
+        estimator_list=["lgbm"],
+    )
+    assert automl.model is not None
+
+
 def test_groups_for_classification_task():
     from sklearn.externals._arff import ArffException
 


### PR DESCRIPTION
## Why are these changes needed?

Two related bugs in `GenericTask.prepare_data` that surface together whenever a user combines a non-shuffle split (`split_type="time"` or `"group"`) with `sample_weight`:

1. **#1553 (`ValueError: Found input variables with inconsistent numbers of samples`)** — `prepare_data` was splitting the data twice. The `if split_type == "group":` branch at `flaml/automl/task/generic_task.py:956` was a standalone `if`, so after the `time`/`group` branch ran (correctly subsetting `state.fit_kwargs["sample_weight"]`), the chained `elif self.is_classification()` / `elif self.is_regression()` branches also fired and tried to split the already-subset weight against the still-full `X_train_all`. One-character fix: chain the `group` branch off the preceding `time` branch with `elif`.

2. **#887 (`AttributeError: 'AutoMLState' has no attribute 'sample_weight_all'`)** — `AutoMLState.prepare_sample_train_data` reads `self.sample_weight_all` whenever `"sample_weight"` is in `fit_kwargs`, but the attribute was only set inside the `SHUFFLE_SPLIT_TYPES` branch. For `split_type="time"` or `"group"` (or any other non-shuffle path), the attribute was never created, raising the AttributeError during the final retrain step. Fix proposed by @sonichi in #887 (2023): initialize `state.sample_weight_all = sample_weight_full` once before the shuffle branching; the SHUFFLE branch still overwrites it after `shuffle(...)` returns the shuffled weight.

The two bugs surface in the same call (`AutoML.fit(... split_type="time", sample_weight=..., retrain_full=True)`) — the `ValueError` fires first in `prepare_data`, and once that's fixed, the `AttributeError` becomes reachable during the retrain step. So both fixes share a single regression test.

## Related issue number

Closes #887
Closes #1553

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.