### PR TITLE
fix: LRL1/LRL2 — migrate off sklearn 1.10 deprecations (penalty, n_jobs)

### DIFF
--- a/flaml/automl/model.py
+++ b/flaml/automl/model.py
@@ -2034,7 +2034,11 @@ class LRL1Classifier(SKLearnEstimator):
         params = super().config2params(config)
         params["tol"] = params.get("tol", 0.0001)
         params["solver"] = params.get("solver", "saga")
-        params["penalty"] = params.get("penalty", "l1")
+        if SKLEARN_VERSION >= "1.8":
+            params["l1_ratio"] = params.get("l1_ratio", 1.0)
+            params.pop("n_jobs", None)
+        else:
+            params["penalty"] = params.get("penalty", "l1")
         return params
 
     def __init__(self, task="binary", **config):
@@ -2063,7 +2067,10 @@ class LRL2Classifier(SKLearnEstimator):
         params = super().config2params(config)
         params["tol"] = params.get("tol", 0.0001)
         params["solver"] = params.get("solver", "lbfgs")
-        params["penalty"] = params.get("penalty", "l2")
+        if SKLEARN_VERSION >= "1.8":
+            params.pop("n_jobs", None)
+        else:
+            params["penalty"] = params.get("penalty", "l2")
         return params
 
     def __init__(self, task="binary", **config):


### PR DESCRIPTION
## Why are these changes needed?

`LRL1Classifier` and `LRL2Classifier` configure sklearn's `LogisticRegression` with two arguments that were deprecated in scikit-learn 1.8 and scheduled for removal in scikit-learn 1.10:

- `penalty=` (use `l1_ratio` or `C` instead — `l1_ratio=1` for L1, `l1_ratio=0` for L2)
- `n_jobs=` (has no effect since 1.8 — `SGDEstimator.config2params` already pops this for the regression case)

Each `lrl1` / `lrl2` fit on sklearn ≥ 1.8 currently emits a `FutureWarning` for `penalty`, a `UserWarning` for `penalty=l1 with l1_ratio=0.0`, and a `FutureWarning` for `n_jobs`. Once scikit-learn 1.10 ships, these become `TypeError`s and the two estimators hard-break.

This PR version-gates the configuration in `config2params` using the existing `SKLEARN_VERSION` constant in `flaml/automl/model.py` (already in use for the SGD `loss` migration at lines 2383 and 2437):

- **`LRL1Classifier`**: on sklearn ≥ 1.8, set `l1_ratio=1.0` and drop `n_jobs`; on older sklearn, keep `penalty="l1"`.
- **`LRL2Classifier`**: on sklearn ≥ 1.8, just drop `n_jobs` (the default `LogisticRegression` penalty is already `"l2"`); on older sklearn, keep `penalty="l2"`.

Verified locally on sklearn 1.8.0: both migrations produce identical `coef_` to the legacy configuration, the existing `lrl1` / `lrl2` reproducibility tests continue to pass, and no `FutureWarning` / `UserWarning` about `penalty` or `n_jobs` is emitted during fit.

## Related issue number

Closes #1555

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.