### PR TITLE
fix: FLOW2.reach() handles mixed-type conditional parameters (#903)

### DIFF
--- a/flaml/tune/searcher/flow2.py
+++ b/flaml/tune/searcher/flow2.py
@@ -674,5 +674,8 @@ class FLOW2(Searcher):
             # unordered cat choice is hard to reach by chance
             if config1[key] != config2.get(key):
                 return False
-        delta = np.array([incumbent1[key] - incumbent2.get(key, np.inf) for key in self._tunable_keys])
+        try:
+            delta = np.array([incumbent1[key] - incumbent2.get(key, np.inf) for key in self._tunable_keys])
+        except TypeError:
+            return False
         return np.linalg.norm(delta) <= self.step

--- a/test/tune/test_searcher.py
+++ b/test/tune/test_searcher.py
@@ -345,5 +345,25 @@ def test_unresolved_search_space(caplog):
     ), "BlendSearch should not produce warning about unresolved search space"
 
 
+def test_flow2_reach_mixed_type_incumbents():
+    """Regression test for #903: FLOW2.reach() must return False instead of raising
+    TypeError when conditional choice parameters lead to mixed-type incumbents."""
+    from flaml.tune.searcher.flow2 import FLOW2
+
+    f1 = FLOW2.__new__(FLOW2)
+    f1.best_config = {"x": 1.0}
+    f1.incumbent = {"x": 1.0}
+    f1._resource = None
+    f1._unordered_cat_hp = {}
+    f1._tunable_keys = ["x"]
+    f1.step = 0.5
+
+    f2 = FLOW2.__new__(FLOW2)
+    f2.best_config = {"x": "None"}
+    f2.incumbent = {"x": "None"}
+
+    assert f1.reach(f2) is False
+
+
 if __name__ == "__main__":
     test_unresolved_search_space(None)

--- a/test/tune/test_searcher.py
+++ b/test/tune/test_searcher.py
@@ -346,8 +346,10 @@ def test_unresolved_search_space(caplog):
 
 
 def test_flow2_reach_mixed_type_incumbents():
-    """Regression test for #903: FLOW2.reach() must return False instead of raising
-    TypeError when conditional choice parameters lead to mixed-type incumbents."""
+    """Regression test for #903.
+
+    FLOW2.reach() must return False instead of raising TypeError when conditional choice parameters lead to mixed-type incumbents.
+    """
     from flaml.tune.searcher.flow2 import FLOW2
 
     f1 = FLOW2.__new__(FLOW2)


### PR DESCRIPTION
## Why are these changes needed?

`FLOW2.reach` in `flaml/tune/searcher/flow2.py` builds a numeric `delta` array by subtracting two incumbents element-wise:

```python
delta = np.array([incumbent1[key] - incumbent2.get(key, np.inf) for key in self._tunable_keys])
```

When a search space contains a conditional `tune.choice` whose branches yield values of different types — e.g. one branch returns the literal string `'None'` and another returns an int from `tune.qrandint` (the exact pattern from #903) — two FLOW2 instances can hold incumbents whose values are different types for the same key. The subtraction then raises:

```
TypeError: unsupported operand type(s) for -: 'float' and 'str'
```

This was reported by @bbudescu in #903 (2023-01); @sonichi's suggested fix in that thread is to wrap the line in `try/except TypeError` and return `False`. This PR implements exactly that. Returning `False` is the right semantics here — a string-vs-numeric incumbent comparison is structurally not "within step" of each other, so reporting "cannot reach" is correct.

## Verified

- Repro from #903 reproduces cleanly on current main via `FLOW2.reach()` (`TypeError: unsupported operand type(s) for -: 'float' and 'str'`).
- After the fix, `reach()` returns `False` for the mixed-type case (no crash).
- A focused regression test was added in `test/tune/test_searcher.py::test_flow2_reach_mixed_type_incumbents` — verified to fail on main without the fix and pass with it.
- Existing tests in `test/tune/test_searcher.py` continue to pass.
- `pre-commit run --files flaml/tune/searcher/flow2.py test/tune/test_searcher.py` — all hooks pass.

## Related issue number

Closes #903

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.