### PR TITLE
docs: ensemble component predict pattern + regression test (#1136)

### DIFF
--- a/flaml/automl/automl.py
+++ b/flaml/automl/automl.py
@@ -890,6 +890,14 @@ class AutoML(BaseEstimator):
 
             # Apply task-level preprocessing to new data
             X_test_preprocessed = automl.preprocess(X_test)
+
+            # Required when calling a single ensemble component directly, since
+            # `automl.model.estimators_[i]` was fitted on already-preprocessed
+            # data and cannot consume raw input (see issue #1136):
+            automl_ensemble = AutoML()
+            automl_ensemble.fit(X_train, y_train, task="classification", ensemble=True)
+            X_test_preprocessed = automl_ensemble.preprocess(X_test)
+            component_pred = automl_ensemble.model.estimators_[0].predict(X_test_preprocessed)
             ```
         """
         if not hasattr(self, "_state") or self._state is None:

--- a/test/automl/test_regression.py
+++ b/test/automl/test_regression.py
@@ -244,6 +244,68 @@ def test_multioutput():
     print(model.predict(X_test))
 
 
+def test_ensemble_component_predict_via_public_preprocess():
+    """Regression coverage for #1136 — ensemble component models trained on data with
+    categorical features cannot consume raw input; consumers must apply the public
+    `automl.preprocess(X)` method (added in #1497) before delegating to a single
+    component picked out of `automl.model.estimators_`."""
+    import pandas as pd
+
+    rng = np.random.RandomState(42)
+    n = 400
+    df = pd.DataFrame(
+        {
+            "age": rng.randint(20, 70, n),
+            "income": rng.normal(50000, 15000, n),
+            "gender": rng.choice(["M", "F"], n),
+            "education": rng.choice(["HS", "BS", "MS", "PhD"], n),
+        }
+    )
+    y_true = (
+        0.02 * df["age"]
+        + 0.00001 * df["income"]
+        + (df["gender"] == "M").astype(int) * 0.5
+        + df["education"].map({"HS": 0, "BS": 0.3, "MS": 0.6, "PhD": 1.0}).values
+        + rng.normal(0, 0.1, n)
+    )
+
+    automl = AutoML()
+    automl.fit(
+        df,
+        y_true,
+        task="regression",
+        ensemble=True,
+        n_jobs=1,
+        time_budget=-1,
+        max_iter=12,
+        estimator_list=["lgbm", "xgboost", "rf"],
+        verbose=0,
+    )
+
+    components = getattr(automl.model, "estimators_", None)
+    if components is None:
+        pytest.skip("ensemble did not build with this configuration")
+
+    # Public predict on the top-level AutoML continues to work (sanity check).
+    top_pred = automl.predict(df)
+    assert len(top_pred) == n
+
+    # Component models cannot consume raw input — this is the original #1136 failure.
+    raised = 0
+    for est in components:
+        try:
+            est.predict(df)
+        except Exception:
+            raised += 1
+    assert raised >= 1, "expected at least one component to fail on raw categorical input"
+
+    # The public `preprocess(X)` API (added in #1497) is the supported workaround.
+    df_preprocessed = automl.preprocess(df)
+    for est in components:
+        pred = est.predict(df_preprocessed)
+        assert len(pred) == n
+
+
 @pytest.mark.parametrize(
     "estimator",
     [


### PR DESCRIPTION
## Why are these changes needed?

[#1136](https://github.com/microsoft/FLAML/issues/1136) reported a long-standing footgun: when `automl.fit(..., ensemble=True)` is used on a DataFrame with categorical features, calling `automl.model.estimators_[i].predict(X_raw)` on a single ensemble component throws cryptic errors (LightGBM `train and valid dataset categorical_feature do not match`, XGBoost `DataFrame.dtypes for data must be int, float, bool or category`, sklearn estimators `feature_names should match those that were passed during fit`). The reporter found a workaround that reached into private state: `automl._state.task.preprocess(X, automl._transformer)`.

PR #1497 (merged 2026-01-21) already added the public `automl.preprocess(X)` method that performs exactly this transformation without touching private state. The underlying functional gap is therefore already closed — but the docstring example didn't show the ensemble-component case, and there was no regression test pinning the original failure surface. This PR closes both gaps:

- `flaml/automl/automl.py` — extend the `preprocess()` docstring example to show the per-component prediction pattern, referencing `#1136`.
- `test/automl/test_regression.py` — add `test_ensemble_component_predict_via_public_preprocess`, which builds an ensemble on a DataFrame with categorical features (`gender`, `education` — the exact failure surface from `#1136`), asserts that at least one component fails on raw input, and verifies all components succeed once data is run through `automl.preprocess(X)`.

After this lands, #1136 can be closed.

## Verified locally

- New test: `pytest test/automl/test_regression.py::test_ensemble_component_predict_via_public_preprocess` — passes.
- Adjacent `test_multioutput` test continues to pass.
- `pre-commit run --files flaml/automl/automl.py test/automl/test_regression.py` — all hooks pass.

## Related issue number

Closes #1136 (functional resolution shipped in #1497; this PR adds the missing example + regression test).

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.