### PR TITLE
docs: cross-link AutoML and zero-shot LightGBM notebooks

### DIFF
--- a/notebook/automl_lightgbm.ipynb
+++ b/notebook/automl_lightgbm.ipynb
@@ -35,6 +35,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** This notebook covers hyperparameter tuning. If you'd rather skip the tuning cost entirely, see [Zero-Shot  AutoML with LightGBM](zeroshot_lightgbm.ipynb) for a data-dependent default configuration."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/notebook/zeroshot_lightgbm.ipynb
+++ b/notebook/zeroshot_lightgbm.ipynb
@@ -32,6 +32,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** This notebook covers zero-shot AutoML. If you want full hyperparameter search instead, see [Tune LightGBM with FLAML](automl_lightgbm.ipynb) for the tuning-based approach."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
## Why are these changes needed?

Right now the AutoML tuning notebook (`automl_lightgbm.ipynb`) and the zero-shot notebook (`zeroshot_lightgbm.ipynb`) don't reference each other. Someone who opens one has no way of knowing the other approach exists, even though they solve the same problem differently (tuning vs. instant data-dependent defaults). Added a short note in each notebook, right before the install step, linking to the other so users can pick the approach that fits their use case before running anything.

## Related issue number

Closes #737

## Checks

- [ ] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [x] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.