### PR TITLE
docs: fix undefined variable and comment mismatch in time series forecast example

### DIFF
--- a/notebook/automl_time_series_forecast.ipynb
+++ b/notebook/automl_time_series_forecast.ipynb
@@ -1667,7 +1667,7 @@
     "    lambda x: above_monthly_avg(x[\"timeStamp\"], x[\"temp\"]), axis=1\n",
     ")\n",
     "\n",
-    "del multi_df[\"month\"]  # remove temperature column to reduce redundancy"
+    "del multi_df[\"month\"]  # remove month column to reduce redundancy"
    ]
   },
   {

--- a/website/docs/Examples/AutoML-Time series forecast.md
+++ b/website/docs/Examples/AutoML-Time series forecast.md
@@ -531,7 +531,7 @@ settings = {
 }
 
 # train the model
-automl.fit(dataframe=multi_train_df, **settings, period=time_horizon)
+automl.fit(dataframe=multi_train_df, **settings, period=multi_time_horizon)
 
 # predictions
 print(automl.predict(multi_X_test))

--- a/website/docs/Examples/AutoML-Time series forecast.md
+++ b/website/docs/Examples/AutoML-Time series forecast.md
@@ -502,7 +502,7 @@ multi_df["temp_above_monthly_avg"] = multi_df.apply(
     lambda x: above_monthly_avg(x["timeStamp"], x["temp"]), axis=1
 )
 
-del multi_df["month"]  # remove temperature column to reduce redundancy
+del multi_df["month"]  # remove month column to reduce redundancy
 
 # split data into train and test
 num_samples = multi_df.shape[0]
@@ -531,7 +531,7 @@ settings = {
 }
 
 # train the model
-automl.fit(dataframe=df, **settings, period=time_horizon)
+automl.fit(dataframe=multi_train_df, **settings, period=time_horizon)
 
 # predictions
 print(automl.predict(multi_X_test))


### PR DESCRIPTION
Fixes #1173 and #1174 (part of #1570).

In `website/docs/Examples/AutoML-Time series forecast.md`:
- Fix `NameError` in multivariate forecasting example: update `dataframe=df` to `dataframe=multi_train_df` (the DataFrame created in preceding steps).
- Fix comment mismatch: update `# remove temperature column to reduce redundancy` to `# remove month column to reduce redundancy`.