### PR TITLE
Fix misaligned sample_weight in group holdout split

### DIFF
--- a/flaml/automl/task/generic_task.py
+++ b/flaml/automl/task/generic_task.py
@@ -964,6 +964,15 @@ class GenericTask(Task):
                     y_train, y_val = y_train_all[train_idx], y_train_all[val_idx]
                     state.groups = state.groups_all[train_idx]
                     state.groups_val = state.groups_all[val_idx]
+                    if "sample_weight" in state.fit_kwargs:
+                        # NOTE: _prepare_data is before kwargs is updated to fit_kwargs_by_estimator
+                        weight = state.fit_kwargs["sample_weight"]
+                        if isinstance(weight, pd.Series):
+                            state.fit_kwargs["sample_weight"] = weight.iloc[train_idx]
+                            state.weight_val = weight.iloc[val_idx]
+                        else:
+                            state.fit_kwargs["sample_weight"] = weight[train_idx]
+                            state.weight_val = weight[val_idx]
             elif self.is_classification():
                 # for classification, make sure the labels are complete in both
                 # training and validation data

--- a/flaml/automl/task/generic_task.py
+++ b/flaml/automl/task/generic_task.py
@@ -967,10 +967,15 @@ class GenericTask(Task):
                     if "sample_weight" in state.fit_kwargs:
                         # NOTE: _prepare_data is before kwargs is updated to fit_kwargs_by_estimator
                         weight = state.fit_kwargs["sample_weight"]
-                        if isinstance(weight, pd.Series):
+                        if weight is None:
+                            pass
+                        elif isinstance(weight, pd.Series):
                             state.fit_kwargs["sample_weight"] = weight.iloc[train_idx]
                             state.weight_val = weight.iloc[val_idx]
                         else:
+                            # train_idx/val_idx are ndarrays from GroupShuffleSplit, so a plain
+                            # list or tuple weight needs converting before it supports fancy indexing
+                            weight = np.asarray(weight)
                             state.fit_kwargs["sample_weight"] = weight[train_idx]
                             state.weight_val = weight[val_idx]
             elif self.is_classification():

--- a/test/automl/test_split.py
+++ b/test/automl/test_split.py
@@ -125,6 +125,61 @@ def test_group_split_with_sample_weight_alignment():
     assert automl._state.weight_val is not None
 
 
+def test_group_split_with_sample_weight_series_alignment():
+    """Same regression as above, but sample_weight is a pd.Series with a
+    non-default index, to verify the group branch slices it positionally
+    (.iloc) rather than by label."""
+    from unittest.mock import patch
+
+    from sklearn.ensemble import RandomForestClassifier
+
+    n = 200
+    rng = np.random.default_rng(7)
+    X = pd.DataFrame(
+        {"id": np.arange(n, dtype=float), "feat": rng.normal(size=n)},
+    )
+    groups = np.repeat(np.arange(20), 10)
+    y = pd.Series((groups % 2).astype(int))
+    # non-default index: label != positional order, so .loc and .iloc would disagree
+    weight_index = np.arange(n) + 500
+    sample_weight = pd.Series(1000.0 + np.arange(n, dtype=float), index=weight_index)
+
+    captured = []
+    original_fit = RandomForestClassifier.fit
+
+    def spy_fit(self, X, y, sample_weight=None, **kwargs):
+        captured.append(
+            (
+                np.asarray(X).copy(),
+                None if sample_weight is None else np.asarray(sample_weight, dtype=float).copy(),
+            )
+        )
+        return original_fit(self, X, y, sample_weight=sample_weight, **kwargs)
+
+    automl = AutoML()
+    with patch.object(RandomForestClassifier, "fit", spy_fit):
+        automl.fit(
+            X_train=X,
+            y_train=y,
+            sample_weight=sample_weight,
+            groups=groups,
+            split_type="group",
+            eval_method="holdout",
+            task="classification",
+            time_budget=-1,
+            max_iter=2,
+            estimator_list=["rf"],
+        )
+    assert automl.model is not None
+    assert captured
+    for X_fit, weight_fit in captured:
+        assert weight_fit is not None
+        # each row trains with its own weight (1000 + row id) after the split,
+        # regardless of the Series' original (non-default) index
+        np.testing.assert_array_equal(weight_fit, 1000.0 + np.asarray(X_fit)[:, 0])
+    assert automl._state.weight_val is not None
+
+
 def test_groups_for_classification_task():
     from sklearn.externals._arff import ArffException
 

--- a/test/automl/test_split.py
+++ b/test/automl/test_split.py
@@ -74,6 +74,57 @@ def test_time_split_with_sample_weight():
     assert automl.model is not None
 
 
+def test_group_split_with_sample_weight_alignment():
+    """Regression for group holdout: sample_weight must be split by the group
+    train/val indices, not left full-length and sliced positionally downstream."""
+    from unittest.mock import patch
+
+    from sklearn.ensemble import RandomForestClassifier
+
+    n = 200
+    rng = np.random.default_rng(42)
+    # column 0 is a row id, so each row's expected weight is recoverable from X
+    X = np.column_stack([np.arange(n, dtype=float), rng.normal(size=n)])
+    groups = np.repeat(np.arange(20), 10)
+    y = (groups % 2).astype(int)
+    sample_weight = 1000.0 + np.arange(n, dtype=float)
+
+    captured = []
+    original_fit = RandomForestClassifier.fit
+
+    def spy_fit(self, X, y, sample_weight=None, **kwargs):
+        captured.append(
+            (
+                np.asarray(X).copy(),
+                None if sample_weight is None else np.asarray(sample_weight, dtype=float).copy(),
+            )
+        )
+        return original_fit(self, X, y, sample_weight=sample_weight, **kwargs)
+
+    automl = AutoML()
+    with patch.object(RandomForestClassifier, "fit", spy_fit):
+        automl.fit(
+            X_train=X,
+            y_train=y,
+            sample_weight=sample_weight,
+            groups=groups,
+            split_type="group",
+            eval_method="holdout",
+            task="classification",
+            time_budget=-1,
+            max_iter=2,
+            estimator_list=["rf"],
+        )
+    assert automl.model is not None
+    assert captured
+    for X_fit, weight_fit in captured:
+        assert weight_fit is not None
+        # each row trains with its own weight (1000 + row id) after the split
+        np.testing.assert_array_equal(weight_fit, 1000.0 + np.asarray(X_fit)[:, 0])
+    # the validation loss must be weighted as well
+    assert automl._state.weight_val is not None
+
+
 def test_groups_for_classification_task():
     from sklearn.externals._arff import ArffException
 


### PR DESCRIPTION
## Why are these changes needed?

With `split_type="group"`, `eval_method="holdout"`, and `sample_weight` set, the group branch of `_prepare_data` (flaml/automl/task/generic_task.py:956-966 on main) splits X, y, and groups by `train_idx`/`val_idx` but leaves `state.fit_kwargs["sample_weight"]` at full length and never sets `state.weight_val`. `AutoMLState.prepare_sample_train_data` (flaml/automl/state.py:241) then slices the weights positionally, `weight[:sample_size]`, so every trial trains with weights that belong to other rows: rows after the first held-out group get a neighbor's weight, and the held-out rows' weights land on training rows. Because `weight_val` stays `None`, the validation loss that drives model selection ignores sample weights entirely. All of this is silent, no error is raised, and the wrong model can be selected.

#1554 fixed the crash in this configuration (#887, #1553) by chaining the `"group"` branch as an `elif` and setting `state.sample_weight_all`. It did not change how the weights are split. The pattern this PR follows is the pre-existing one: the `"time"` branch (generic_task.py:913-955) and `_train_test_split` (generic_task.py:309) both split weights into `state.fit_kwargs["sample_weight"]` and `state.weight_val`. The `"group"` branch is the only holdout branch that does not. This PR mirrors that pattern inside the `GroupShuffleSplit` loop, handling both `pd.Series` and array weights.

The regression test encodes each row's expected weight in the row itself (column 0 is a row id, weight is 1000 + id) and spies on `RandomForestClassifier.fit`, so any misalignment between the rows an estimator receives and the weights it receives fails the assert; it also asserts `weight_val` is populated. Without the source change the test fails on the alignment assert; with it, `test/automl/test_split.py` passes 9/9.

Not covered here: the group holdout path still does not handle Spark dataframes (the time branch has an explicit `_split_pyspark` arm, the group branch never did, and `GroupShuffleSplit` cannot split a psDataFrame). That is a pre-existing limitation, and this PR keeps the same pandas/numpy scope as the bug.

## Related issue number

Follow-up to #1554 (issues #887, #1553), which stopped the crash in this configuration but left the group branch's weights unsplit.

## Checks

- [x] I've used [pre-commit](https://microsoft.github.io/FLAML/docs/Contribute#pre-commit) to lint the changes in this PR (note the same in integrated in our CI checks).
- [ ] I've included any doc changes needed for https://microsoft.github.io/FLAML/. See https://microsoft.github.io/FLAML/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.