### PR TITLE
fix: support statsmodels 0.15 in naive forecasters

### DIFF
--- a/flaml/automl/time_series/ts_model.py
+++ b/flaml/automl/time_series/ts_model.py
@@ -699,6 +699,7 @@ class SimpleForecaster(StatsModelsEstimator):
 
         model = SimpleExpSmoothing(
             train_df[[target_col]],
+            initialization_method="estimated",
         )
         with suppress_stdout_stderr():
             model = model.fit(smoothing_level=self.smoothing_level)

--- a/test/automl/test_forecast.py
+++ b/test/automl/test_forecast.py
@@ -123,6 +123,38 @@ def test_models(budget=3):
         automl.predict(X[144:])
 
 
+def test_simple_forecaster_sets_initialization_method(monkeypatch):
+    from statsmodels.tsa.holtwinters import SimpleExpSmoothing
+
+    initialization_methods = []
+
+    def simple_exp_smoothing(*args, **kwargs):
+        initialization_methods.append(kwargs.get("initialization_method"))
+        return SimpleExpSmoothing(*args, **kwargs)
+
+    monkeypatch.setattr("statsmodels.tsa.holtwinters.SimpleExpSmoothing", simple_exp_smoothing)
+
+    data = pd.DataFrame(
+        {
+            "ds": pd.date_range("2024-01-01", periods=30, freq="D"),
+            "y": np.linspace(10.0, 20.0, 30),
+        }
+    )
+    automl = AutoML()
+    automl.fit(
+        dataframe=data,
+        label="y",
+        task="ts_forecast",
+        estimator_list=["naive"],
+        period=3,
+        max_iter=1,
+        verbose=0,
+    )
+
+    assert initialization_methods
+    assert set(initialization_methods) == {"estimated"}
+
+
 def test_numpy():
     X_train = np.arange("2014-01", "2021-01", dtype="datetime64[M]")
     y_train = np.random.random(size=len(X_train))


### PR DESCRIPTION
## Why are these changes needed?

Statsmodels 0.15.0 was released on August 27 and changed `SimpleExpSmoothing` so its wrapper still supplies `initialization_method=None` while the base `ExponentialSmoothing` constructor now requires a string. FLAML's `naive` and `snaive` estimators consequently fail with `TypeError: initialization_method must be a string`.

This failure reproduces on scheduled builds of `main` and is also the cause of the failing build matrix in #1568 (and newer unrelated PRs), so it is not introduced by those PR changes.

## What does this PR do?

- Passes `initialization_method="estimated"` explicitly when constructing `SimpleExpSmoothing`, preserving the documented pre-0.15 default behavior.
- Adds a regression test that verifies FLAML always supplies the explicit initialization method.

## Verification

- `pytest test/automl/test_forecast.py::test_simple_forecaster_sets_initialization_method -q`
- `pre-commit run --files flaml/automl/time_series/ts_model.py test/automl/test_forecast.py`