### PR TITLE
Docs: use consistent four-space indentation in Task-Oriented AutoML

### DIFF
--- a/website/docs/Use-Cases/Task-Oriented-AutoML.md
+++ b/website/docs/Use-Cases/Task-Oriented-AutoML.md
@@ -752,10 +752,10 @@ print(automl.model)
 print(automl.model.estimator)
 """
 LGBMRegressor(colsample_bytree=0.7610534336273627,
-              learning_rate=0.41929025492645006, max_bin=255,
-              min_child_samples=4, n_estimators=45, num_leaves=4,
-              reg_alpha=0.0009765625, reg_lambda=0.009280655005879943,
-              verbose=-1)
+    learning_rate=0.41929025492645006, max_bin=255,
+    min_child_samples=4, n_estimators=45, num_leaves=4,
+    reg_alpha=0.0009765625, reg_lambda=0.009280655005879943,
+    verbose=-1)
 """
 ```
 


### PR DESCRIPTION
## Why are these changes needed?

Closes #884. The multiline `LGBMRegressor` example in the Task-Oriented AutoML documentation used 14 spaces for continuation lines while the surrounding documentation uses four-space indentation. This patch changes those continuation lines to four spaces for consistent rendering and readability.

## Validation

- Verified that every nonblank line in a fenced code block in the affected document has indentation divisible by four spaces.
- Ran `git diff --check`.

Validation observed for this change:
- `python - <<'PY'
from pathlib import Path
path = Path('website/docs/Use-Cases/Task-Oriented-AutoML.md')
in_code = False
violations = []
for number, line in enumerate(path.read_text().splitlines(), 1):
    if line.startswith('```'):
        in_code = not in_code
    elif in_code and line.strip():
        spaces = len(line) - len(line.lstrip(' '))
        if spaces % 4:
            violations.append((number, spaces))
assert not violations, f'inconsistent code-block indentation: {violations}'
print('All nonblank code-block indentation is a multiple of four spaces.')
PY`
- `git diff --check && git diff -- website/docs/Use-Cases/Task-Oriented-AutoML.md && git status --short`

Fixes #884

<!-- repo-agent-case:5570d1af-458a-422e-a39f-df059d00cae4 -->