### PR TITLE
Honor unit quantization for float sampling

### DIFF
--- a/flaml/tune/sample.py
+++ b/flaml/tune/sample.py
@@ -456,7 +456,7 @@ class Quantized(Sampler):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
 
-        if self.q == 1:
+        if self.q == 1 and isinstance(domain, Integer):
             return self.sampler.sample(domain, spec, size, random_state=random_state)
 
         quantized_domain = copy(domain)

--- a/test/tune/test_unit_quantization.py
+++ b/test/tune/test_unit_quantization.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from flaml.tune.sample import qloguniform, qrandn, quniform
+
+
+@pytest.mark.parametrize(
+    "factory", [lambda q: quniform(2, 10, q), lambda q: qloguniform(2, 10, q), lambda q: qrandn(0, 2, q)]
+)
+@pytest.mark.parametrize("size", [1, 100])
+@pytest.mark.parametrize("q", [1, 2, 0.5])
+def test_unit_quantization_rounds_float_samples(factory, size, q):
+    values = np.asarray(factory(q).sample(size=size, random_state=42))
+    np.testing.assert_array_equal(values / q, np.round(values / q))
+    np.testing.assert_array_equal(values, factory(q).sample(size=size, random_state=42))


### PR DESCRIPTION
## Why are these changes needed?

Quantized float domains bypass rounding when q=1, returning continuous values instead of the documented integer increments. This affects quniform, qloguniform and qrandn when using the built-in sampler.

Limit the q=1 fast path to integer domains; float domains use the existing quantization path. Tests cover all three distributions, scalar and batched samples, non-unit steps, and deterministic seeded sampling.

## Validation

6 regressions fail before the fix; 23 tests pass afterward across the new tests, test_sample.py, test_stop.py and test_reproducibility.py. Validation used Python 3.12 on CPU, with Optuna installed and without Ray. Full repository `pre-commit run --all-files` passes (pre-commit 3.7.1, compatible with the local Git version).

## Checks

- [x] Pre-commit hooks run and passed.
- [x] Regression tests added.
- [x] Existing documented behavior restored; no new public API.
- [ ] Upstream CI checks complete.

Implementation and validation were performed with AI assistance.

Fixes #1598.
