### PR TITLE
Compute trial averages from per-metric report counts

### DIFF
--- a/flaml/tune/trial.py
+++ b/flaml/tune/trial.py
@@ -109,13 +109,15 @@ class Trial:
                         "last": value,
                     }
                     self.metric_n_steps[metric] = {}
+                    self.metric_n_reports[metric] = 1
                     for n in self.n_steps:
                         key = f"last-{n:d}-avg"
                         self.metric_analysis[metric][key] = value
                         # Store n as string for correct restore.
                         self.metric_n_steps[metric][str(n)] = deque([value], maxlen=n)
                 else:
-                    step = result["training_iteration"] or 1
+                    self.metric_n_reports[metric] += 1
+                    step = self.metric_n_reports[metric]
                     self.metric_analysis[metric]["max"] = max(value, self.metric_analysis[metric]["max"])
                     self.metric_analysis[metric]["min"] = min(value, self.metric_analysis[metric]["min"])
                     self.metric_analysis[metric]["avg"] = (

--- a/flaml/tune/trial_runner.py
+++ b/flaml/tune/trial_runner.py
@@ -40,6 +40,7 @@ class SimpleTrial(Trial):
         self.metric_analysis = {}
         self.n_steps = [5, 10]
         self.metric_n_steps = {}
+        self.metric_n_reports = {}
 
 
 class BaseTrialRunner:

--- a/test/tune/test_metric_average.py
+++ b/test/tune/test_metric_average.py
@@ -1,0 +1,18 @@
+import pytest
+
+from flaml import tune
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_average_counts_reported_metric_values(sparse):
+    def evaluate(config):
+        for value in [1.0, 3.0, 5.0]:
+            tune.report(score=value, secondary=value)
+            if sparse:
+                tune.report(score=value)
+
+    analysis = tune.run(evaluate, config={}, metric="score", mode="min", num_samples=1, use_ray=False, verbose=0)
+    stats = analysis.trials[0].metric_analysis
+    assert stats["score"]["avg"] == pytest.approx(3.0)
+    assert stats["secondary"]["avg"] == pytest.approx(3.0)
+    assert analysis.get_best_trial(metric="secondary", mode="min", scope="avg") is analysis.trials[0]


### PR DESCRIPTION
## Why are these changes needed?

Trial averages use the zero-based training_iteration as their denominator. Reporting scores 1, 3, 5 produces an average of 4 rather than 3. Sparse secondary metrics also use the wrong denominator, which can affect get_best_trial(scope="avg").

Track the number of reports separately for each metric and use that count in the running average. Tests exercise the public tune.run/report path with both dense and sparse reports.

## Validation

2 regressions fail before the fix; 7 tests pass afterward across the new tests, test_sample.py, test_stop.py and test_reproducibility.py. Validation used Python 3.12 on CPU, with Optuna installed and without Ray. Full repository `pre-commit run --all-files` passes (pre-commit 3.7.1, compatible with the local Git version).

## Checks

- [x] Pre-commit hooks run and passed.
- [x] Regression tests added.
- [x] Existing documented behavior restored; no new public API.
- [ ] Upstream CI checks complete.

Implementation and validation were performed with AI assistance.

Fixes #1600.
