### PR TITLE
Preserve zero-valued anonymous tuning metrics

### DIFF
--- a/flaml/tune/tune.py
+++ b/flaml/tune/tune.py
@@ -209,7 +209,7 @@ def report(_metric=None, **kwargs):
             # calling tune.report() outside tune.run()
             return
     result = kwargs
-    if _metric:
+    if _metric is not None:
         result[DEFAULT_METRIC] = _metric
     trial = getattr(_runner, "running_trial", None)
     if not trial:

--- a/test/tune/test_zero_metric.py
+++ b/test/tune/test_zero_metric.py
@@ -1,0 +1,18 @@
+import pytest
+
+from flaml import tune
+from flaml.tune.result import DEFAULT_METRIC
+
+
+@pytest.mark.parametrize("value", [0, 0.0, False, 1.0, -1.0])
+@pytest.mark.parametrize("report_directly", [False, True])
+def test_anonymous_zero_metric_is_recorded(value, report_directly):
+    def evaluate(config):
+        if report_directly:
+            tune.report(value)
+        else:
+            return value
+
+    analysis = tune.run(evaluate, config={}, mode="min", num_samples=1, use_ray=False, verbose=0)
+    assert analysis.trials[0].last_result[DEFAULT_METRIC] == value
+    assert analysis.best_trial is analysis.trials[0]


### PR DESCRIPTION
## Why are these changes needed?

Returning 0 from an objective, or calling tune.report(0), drops the anonymous metric because report tests its truthiness. The default optimizer then raises KeyError: _metric instead of accepting the valid zero loss.

Use an explicit None check for the optional anonymous metric. Tests exercise returned and directly reported zero values, False, and positive/negative controls through a real tuning run.

## Validation

6 regressions fail before the fix; 15 tests pass afterward across the new tests, test_sample.py, test_stop.py and test_reproducibility.py. Validation used Python 3.12 on CPU, with Optuna installed and without Ray. Full repository `pre-commit run --all-files` passes (pre-commit 3.7.1, compatible with the local Git version).

## Checks

- [x] Pre-commit hooks run and passed.
- [x] Regression tests added.
- [x] Existing documented behavior restored; no new public API.
- [ ] Upstream CI checks complete.

Implementation and validation were performed with AI assistance.

Fixes #1602.
